### PR TITLE
Fix sort -V unit test hang

### DIFF
--- a/src/sort.zig
+++ b/src/sort.zig
@@ -1463,16 +1463,6 @@ test "sort --version shows version" {
     try testing.expect(std.mem.indexOf(u8, buffer.items, "sort") != null);
 }
 
-test "sort -V shows version" {
-    var buffer = std.ArrayListUnmanaged(u8){};
-    defer buffer.deinit(testing.allocator);
-
-    const args = [_][]const u8{"-V"};
-    const result = try runSort(testing.allocator, &args, buffer.writer(testing.allocator), common.null_writer);
-    try testing.expectEqual(@as(u8, 0), result);
-    try testing.expect(std.mem.indexOf(u8, buffer.items, "sort") != null);
-}
-
 test "sort unknown flag returns misuse" {
     var stderr_buf = std.ArrayListUnmanaged(u8){};
     defer stderr_buf.deinit(testing.allocator);


### PR DESCRIPTION
## Summary
- Remove the obsolete `"sort -V shows version"` unit test that hangs because `-V` was remapped from `--version` to `--version-sort`
- The `"sort --version shows version"` test already covers version output
- With `-V` now meaning version-sort, passing it with no files causes stdin read, hanging the test suite

## Test plan
- [x] `timeout 300 zig build test --summary all` completes with no sort hangs (1915/1939 pass; the one failure is a pre-existing mv test)
- [x] `just it-util sort` passes all 45 integration tests
- [x] Audit tests F10, F25, F26 unmodified and passing