### PR TITLE
Fix df, nl integration test regressions

### DIFF
--- a/tests/utilities/df_test.sh
+++ b/tests/utilities/df_test.sh
@@ -36,13 +36,13 @@ test_df() {
 
     echo -e "${CYAN}Testing POSIX portability mode...${NC}"
 
-    # -P should show 1K-blocks (POSIX mode)
+    # -P should show 1024-blocks (POSIX mode)
     output=$("$binary" -P / 2>/dev/null)
     exit_code=$?
-    if [[ $exit_code -eq 0 && "$output" =~ "1K-blocks" ]]; then
-        print_test_result "df -P shows 1K-blocks" "PASS"
+    if [[ $exit_code -eq 0 && "$output" =~ "1024-blocks" ]]; then
+        print_test_result "df -P shows 1024-blocks" "PASS"
     else
-        print_test_result "df -P shows 1K-blocks" "FAIL"
+        print_test_result "df -P shows 1024-blocks" "FAIL"
     fi
 
     echo -e "${CYAN}Testing specific path...${NC}"

--- a/tests/utilities/nl_test.sh
+++ b/tests/utilities/nl_test.sh
@@ -27,9 +27,9 @@ test_nl() {
     test_command_output "nl default non-empty" "     1	hello
      2	world" "$binary" "$simple_file"
 
-    # Default skips blank lines
+    # Default skips blank lines (GNU outputs width+sep spaces for blank lines)
     test_command_output "nl default skips blanks" "     1	hello
-
+       
      2	world" "$binary" "$blank_file"
 
     echo -e "${CYAN}Testing body numbering styles (-b)...${NC}"
@@ -41,12 +41,12 @@ test_nl() {
 
     # -b t: number non-empty (default)
     test_command_output "nl -b t numbers non-empty" "     1	hello
-
+       
      2	world" "$binary" -b t "$blank_file"
 
     # -b n: number no lines
-    test_command_output "nl -b n numbers none" "      	hello
-      	world" "$binary" -b n "$simple_file"
+    test_command_output "nl -b n numbers none" "       hello
+       world" "$binary" -b n "$simple_file"
 
     # --body-numbering long option
     test_command_output "nl --body-numbering=a" "     1	hello


### PR DESCRIPTION
## Summary
- Update `df -P` integration test to check for `1024-blocks` instead of `1K-blocks` (POSIX-correct header was implemented in audit fix F20 but the pre-existing test was not updated)
- Update 3 `nl` integration tests to match GNU-compatible unnumbered line format (spaces-only, no tab separator) implemented in audit fixes F40/F41

## Context
The audit fix waves correctly changed df and nl output to match GNU behavior, and updated unit tests accordingly, but missed updating 4 pre-existing integration tests. These are the only regressions found across all 8 triaged utilities (df, du, wc, nl, tr, tee, cp, chown). All other failing integration tests are known RED tests for unimplemented features (F29, F30, F58-F60, F70, F71).

## Test plan
- [x] `just it-util df` -- 16/16 pass (was 15/16)
- [x] `just it-util nl` -- 49/49 pass (was 46/49)
- [x] `just it-util du` -- 22/22 pass (unchanged)
- [x] `just it-util wc` -- 95/115 pass (20 RED tests for F29/F30, unchanged)
- [x] `just it-util tr` -- 48/49 pass (1 RED test, unchanged)
- [x] `just it-util tee` -- 88/93 pass (5 RED tests for F58-F60, unchanged)
- [x] `just it-util cp` -- 135/137 pass (2 RED tests for F70, unchanged)
- [x] `just it-util chown` -- 86/87 pass (1 RED test for F71, unchanged)
- [x] `zig build test` -- 1916/1940 pass (pre-existing sort/mv test timeouts)