### PR TITLE
Add failing tests for IMPORTANT audit findings (wave 5)

### DIFF
--- a/src/id.zig
+++ b/src/id.zig
@@ -1287,3 +1287,48 @@ test "id default format with named user includes all groups" {
     // F47: default format with named user should list same number of groups
     try testing.expectEqual(no_user_comma_count, named_comma_count);
 }
+
+// ============================================================================
+// Audit finding tests (IMPORTANT) — wave 5
+// ============================================================================
+
+test "id -z alone without format flag should exit 2 (GNU rejects)" {
+    // GNU id: "id: cannot print only names or real IDs in default format"
+    // vibeutils currently accepts -z alone and outputs default format with NUL.
+    // GNU rejects -z without -u/-g/-G, exiting 2.
+    var stdout_buffer = try std.ArrayList(u8).initCapacity(testing.allocator, 0);
+    defer stdout_buffer.deinit(testing.allocator);
+
+    var stderr_buffer = try std.ArrayList(u8).initCapacity(testing.allocator, 0);
+    defer stderr_buffer.deinit(testing.allocator);
+
+    const args = [_][]const u8{"-z"};
+    const result = try runId(testing.allocator, &args, stdout_buffer.writer(testing.allocator), stderr_buffer.writer(testing.allocator));
+
+    // GNU behavior: -z alone is an error (exit 2)
+    try testing.expectEqual(@as(u8, 2), result);
+    // stderr should contain a diagnostic message
+    try testing.expect(stderr_buffer.items.len > 0);
+}
+
+test "id -a is a no-op in GNU, not an alias for -G" {
+    // GNU id: -a is ignored (has no effect in default format).
+    // vibeutils treats -a as -G, changing the output format.
+    // Expected: id -a should produce the SAME output as plain id.
+    var stdout_default = try std.ArrayList(u8).initCapacity(testing.allocator, 0);
+    defer stdout_default.deinit(testing.allocator);
+    var stdout_with_a = try std.ArrayList(u8).initCapacity(testing.allocator, 0);
+    defer stdout_with_a.deinit(testing.allocator);
+
+    const args_default = [_][]const u8{};
+    const result_default = try runId(testing.allocator, &args_default, stdout_default.writer(testing.allocator), common.null_writer);
+    try testing.expectEqual(@as(u8, 0), result_default);
+
+    const args_a = [_][]const u8{"-a"};
+    const result_a = try runId(testing.allocator, &args_a, stdout_with_a.writer(testing.allocator), common.null_writer);
+    try testing.expectEqual(@as(u8, 0), result_a);
+
+    // GNU: id -a should produce default format (uid=... gid=... groups=...)
+    // not just the -G style group list
+    try testing.expect(std.mem.indexOf(u8, stdout_with_a.items, "uid=") != null);
+}

--- a/src/sleep.zig
+++ b/src/sleep.zig
@@ -365,3 +365,35 @@ test "TimeUnit.toNanos - verify unit conversions" {
     try testing.expectEqual(std.time.ns_per_hour, time.TimeUnit.hours.toNanos());
     try testing.expectEqual(std.time.ns_per_day, time.TimeUnit.days.toNanos());
 }
+
+// ============================================================================
+// Audit finding tests (IMPORTANT) — wave 5
+// ============================================================================
+
+test "parseTimeString accepts 'inf' (GNU compatible)" {
+    // GNU sleep accepts 'inf' to mean sleep forever.
+    // vibeutils currently rejects 'inf' as InvalidTimeFormat.
+    // Expected: parseTimeString("inf") should succeed and return maxInt(u64).
+    const result = try time.parseTimeString("inf");
+    try testing.expectEqual(std.math.maxInt(u64), result);
+}
+
+test "parseTimeString accepts 'infinity' (GNU compatible)" {
+    // GNU sleep accepts 'infinity' to mean sleep forever.
+    // vibeutils currently rejects 'infinity' as InvalidTimeFormat.
+    const result = try time.parseTimeString("infinity");
+    try testing.expectEqual(std.math.maxInt(u64), result);
+}
+
+test "runSleep error message includes the invalid token" {
+    // GNU sleep: "sleep: invalid time interval 'xyz'"
+    // vibeutils currently says: "sleep: invalid time interval" (no token).
+    var stderr_buffer = try std.ArrayList(u8).initCapacity(testing.allocator, 0);
+    defer stderr_buffer.deinit(testing.allocator);
+
+    const result = try runSleep(testing.allocator, &.{"xyz"}, common.null_writer, stderr_buffer.writer(testing.allocator));
+
+    try testing.expectEqual(@as(u8, 2), result);
+    // The error message should include the invalid token 'xyz'
+    try testing.expect(std.mem.indexOf(u8, stderr_buffer.items, "'xyz'") != null);
+}

--- a/src/timeout.zig
+++ b/src/timeout.zig
@@ -671,3 +671,48 @@ test "runTimeout - missing command after duration returns 125" {
 
     try testing.expectEqual(@as(u8, 125), result);
 }
+
+// ============================================================================
+// Audit finding tests (IMPORTANT) — wave 5
+// ============================================================================
+
+test "runTimeout - --kill-after with quick command exits 0" {
+    // Verify --kill-after is accepted and does not interfere when
+    // the command completes before the timeout.
+    const result = try runTimeout(testing.allocator, &.{ "-k", "5", "10", "true" }, common.null_writer, common.null_writer);
+    try testing.expectEqual(@as(u8, 0), result);
+}
+
+test "runTimeout - --kill-after invalid duration exits 125" {
+    // Invalid --kill-after duration should exit 125 with an error message.
+    var stderr_buffer = try std.ArrayList(u8).initCapacity(testing.allocator, 0);
+    defer stderr_buffer.deinit(testing.allocator);
+
+    const result = try runTimeout(testing.allocator, &.{ "--kill-after", "abc", "10", "true" }, common.null_writer, stderr_buffer.writer(testing.allocator));
+
+    try testing.expectEqual(@as(u8, 125), result);
+    try testing.expect(std.mem.indexOf(u8, stderr_buffer.items, "invalid time interval") != null);
+}
+
+test "runTimeout - --verbose emits signal diagnostic on timeout" {
+    // --verbose should print a diagnostic to stderr when a signal is sent.
+    // Skip on Linux: process group signal delivery is unreliable in the
+    // Zig test runner's IPC mode.
+    if (comptime builtin.os.tag == .linux) return error.SkipZigTest;
+
+    var stderr_buffer = try std.ArrayList(u8).initCapacity(testing.allocator, 0);
+    defer stderr_buffer.deinit(testing.allocator);
+
+    const result = try runTimeout(testing.allocator, &.{ "--verbose", "1", "sleep", "100" }, common.null_writer, stderr_buffer.writer(testing.allocator));
+
+    try testing.expectEqual(@as(u8, 124), result);
+    // --verbose should produce a diagnostic mentioning "sending signal"
+    try testing.expect(std.mem.indexOf(u8, stderr_buffer.items, "sending signal") != null);
+}
+
+test "runTimeout - --foreground with quick command exits 0" {
+    // Verify --foreground is accepted and does not interfere when
+    // the command completes before the timeout.
+    const result = try runTimeout(testing.allocator, &.{ "--foreground", "10", "true" }, common.null_writer, common.null_writer);
+    try testing.expectEqual(@as(u8, 0), result);
+}

--- a/src/yes.zig
+++ b/src/yes.zig
@@ -388,6 +388,34 @@ test "yes with string of exactly 8193 bytes works correctly" {
     try testing.expectEqual(@as(u8, '\n'), output[str_8193.len]);
 }
 
+// ============================================================================
+// Audit finding tests (IMPORTANT) — wave 5
+// ============================================================================
+
+test "yes unknown flag exits 1 (GNU behavior), not 2" {
+    // GNU yes: unknown flags exit 1, not 2.
+    // vibeutils currently exits 2 (misuse).
+    var stderr_buffer = try std.ArrayList(u8).initCapacity(testing.allocator, 0);
+    defer stderr_buffer.deinit(testing.allocator);
+
+    const result = try runYes(testing.allocator, &.{"--unknown-flag"}, common.null_writer, stderr_buffer.writer(testing.allocator));
+
+    // GNU yes exits 1 for unrecognized options
+    try testing.expectEqual(@as(u8, 1), result);
+}
+
+test "yes error message includes the unrecognized flag name" {
+    // GNU yes: "yes: unrecognized option '--unknown-flag'"
+    // vibeutils currently says: "yes: unrecognized option" (no flag name).
+    var stderr_buffer = try std.ArrayList(u8).initCapacity(testing.allocator, 0);
+    defer stderr_buffer.deinit(testing.allocator);
+
+    _ = try runYes(testing.allocator, &.{"--bad-flag"}, common.null_writer, stderr_buffer.writer(testing.allocator));
+
+    // The error message should include the flag name
+    try testing.expect(std.mem.indexOf(u8, stderr_buffer.items, "--bad-flag") != null);
+}
+
 test "yes with string much larger than buffer produces output" {
     // String that is 3x the buffer size
     const huge_str = "C" ** (8192 * 3);

--- a/tests/utilities/id_test.sh
+++ b/tests/utilities/id_test.sh
@@ -173,4 +173,27 @@ test_id() {
         print_test_result "id -gn group name (regression)" "FAIL" \
             "Exit code: $reg_gn_exit, output: '$reg_gn_output'"
     fi
+
+    echo -e "${CYAN}Testing audit findings (wave 5)...${NC}"
+
+    # Audit: id -z alone should be rejected (GNU rejects without -u/-g/-G)
+    "$binary" -z >/dev/null 2>&1
+    exit_code=$?
+    if [[ $exit_code -eq 2 ]]; then
+        print_test_result "id -z alone exits 2 (GNU rejects)" "PASS"
+    else
+        print_test_result "id -z alone exits 2 (GNU rejects)" "FAIL" \
+            "Expected exit 2, got $exit_code"
+    fi
+
+    # Audit: id -a should be a no-op (GNU ignores it in default format)
+    local default_output a_output
+    default_output=$("$binary" 2>/dev/null)
+    a_output=$("$binary" -a 2>/dev/null)
+    if [[ "$a_output" == *"uid="* ]]; then
+        print_test_result "id -a produces default format (no-op)" "PASS"
+    else
+        print_test_result "id -a produces default format (no-op)" "FAIL" \
+            "Expected uid=... format, got '$a_output'"
+    fi
 }

--- a/tests/utilities/sleep_test.sh
+++ b/tests/utilities/sleep_test.sh
@@ -42,4 +42,48 @@ test_sleep() {
     echo -e "${CYAN}Testing sleep 0 exits immediately (arena regression)...${NC}"
 
     test_command_exit_code "sleep 0 exits 0 (arena safety net)" 0 "$binary" 0
+
+    echo -e "${CYAN}Testing audit findings (wave 5)...${NC}"
+
+    # Audit: sleep inf should be accepted (GNU sleeps forever)
+    # Use timeout wrapper to prevent actual infinite sleep
+    timeout 2 "$binary" inf &
+    local inf_pid=$!
+    sleep 0.5
+    # If the process is still running after 0.5s, it accepted "inf"
+    if kill -0 "$inf_pid" 2>/dev/null; then
+        kill "$inf_pid" 2>/dev/null
+        wait "$inf_pid" 2>/dev/null
+        print_test_result "sleep inf accepted (GNU compat)" "PASS"
+    else
+        wait "$inf_pid" 2>/dev/null
+        local inf_exit=$?
+        print_test_result "sleep inf accepted (GNU compat)" "FAIL" \
+            "sleep inf exited immediately with code $inf_exit"
+    fi
+
+    # Audit: sleep infinity should be accepted (GNU sleeps forever)
+    timeout 2 "$binary" infinity &
+    local infinity_pid=$!
+    sleep 0.5
+    if kill -0 "$infinity_pid" 2>/dev/null; then
+        kill "$infinity_pid" 2>/dev/null
+        wait "$infinity_pid" 2>/dev/null
+        print_test_result "sleep infinity accepted (GNU compat)" "PASS"
+    else
+        wait "$infinity_pid" 2>/dev/null
+        local infinity_exit=$?
+        print_test_result "sleep infinity accepted (GNU compat)" "FAIL" \
+            "sleep infinity exited immediately with code $infinity_exit"
+    fi
+
+    # Audit: error message should include the invalid token
+    local sleep_err
+    sleep_err=$("$binary" xyz 2>&1)
+    if [[ "$sleep_err" == *"'xyz'"* ]]; then
+        print_test_result "sleep error includes invalid token" "PASS"
+    else
+        print_test_result "sleep error includes invalid token" "FAIL" \
+            "Expected 'xyz' in error, got: '$sleep_err'"
+    fi
 }

--- a/tests/utilities/timeout_test.sh
+++ b/tests/utilities/timeout_test.sh
@@ -180,4 +180,36 @@ test_timeout() {
         print_test_result "timeout --bad-flag exits 2" "FAIL" \
             "Expected exit 2, got $exit_code"
     fi
+
+    echo -e "${CYAN}Testing audit findings (wave 5)...${NC}"
+
+    # Audit: --kill-after should send KILL if command survives initial signal
+    # Use a trap-ignoring script that ignores TERM but can be killed by KILL
+    local ka_exit
+    "$binary" -k 0.5 -s TERM 0.5 bash -c 'trap "" TERM; sleep 60' >/dev/null 2>&1
+    ka_exit=$?
+    if [[ $ka_exit -eq 137 ]]; then
+        print_test_result "timeout --kill-after sends KILL after grace" "PASS"
+    else
+        print_test_result "timeout --kill-after sends KILL after grace" "FAIL" \
+            "Expected exit 137 (128+KILL), got $ka_exit"
+    fi
+
+    # Audit: --verbose should print diagnostic to stderr when signal is sent
+    local verbose_stderr
+    verbose_stderr=$("$binary" --verbose 0.5 sleep 60 2>&1 >/dev/null)
+    local verbose_exit=$?
+    if [[ "$verbose_stderr" == *"sending signal"* ]]; then
+        print_test_result "timeout --verbose prints signal diagnostic" "PASS"
+    else
+        print_test_result "timeout --verbose prints signal diagnostic" "FAIL" \
+            "Expected 'sending signal' in stderr, got: '$verbose_stderr'"
+    fi
+
+    # Audit: --foreground should not create a new process group
+    # Basic test: command should still complete normally
+    test_command_exit_code "timeout --foreground basic" 0 "$binary" --foreground 10 true
+
+    # --foreground with timeout should still produce exit 124
+    test_command_exit_code "timeout --foreground with timeout" 124 "$binary" --foreground 0.5 sleep 60
 }

--- a/tests/utilities/yes_test.sh
+++ b/tests/utilities/yes_test.sh
@@ -72,6 +72,28 @@ test_yes() {
             "Expected exit code 0, got $exit_code"
     fi
 
+    echo -e "${CYAN}Testing audit findings (wave 5)...${NC}"
+
+    # Audit: unknown flag should exit 1 (GNU), not 2
+    "$binary" --unknown-flag >/dev/null 2>&1
+    exit_code=$?
+    if [[ $exit_code -eq 1 ]]; then
+        print_test_result "yes unknown flag exits 1 (GNU compat)" "PASS"
+    else
+        print_test_result "yes unknown flag exits 1 (GNU compat)" "FAIL" \
+            "Expected exit 1, got $exit_code"
+    fi
+
+    # Audit: error message should include the flag name
+    local yes_err
+    yes_err=$("$binary" --bad-flag 2>&1)
+    if [[ "$yes_err" == *"--bad-flag"* ]]; then
+        print_test_result "yes error includes flag name" "PASS"
+    else
+        print_test_result "yes error includes flag name" "FAIL" \
+            "Expected '--bad-flag' in error, got: '$yes_err'"
+    fi
+
     # Regression test: strings > 8192 bytes must produce output
     echo -e "${CYAN}Testing large string output...${NC}"
 


### PR DESCRIPTION
## Summary
- **id**: Tests for `-z` alone rejection (GNU rejects without format flag) and `-a` as no-op (GNU ignores, not alias for `-G`)
- **sleep**: Tests for `inf`/`infinity` acceptance (GNU sleeps forever), error message including the invalid token
- **yes**: Tests for unknown flag exit code 1 (GNU behavior, not 2) and error message including the flag name
- **timeout**: Tests for `--kill-after`, `--verbose`, and `--foreground` flags (zero test coverage previously)

## Test plan
- [x] Unit tests fail for the right reasons (not compile errors or hangs)
- [x] No test hangs (verified with `timeout 120 zig build test`)
- [ ] Integration tests fail for the right reasons when run via `just it`
- [ ] CI confirms failures match expected audit findings

All tests are RED (intentionally failing). Phase 2 will fix implementations.