### PR TITLE
Fix grep -wo, head --silent/-n -N, cat -E CRLF

### DIFF
--- a/src/cat.zig
+++ b/src/cat.zig
@@ -323,9 +323,17 @@ fn processFormattedLineChunk(writer: anytype, chunk: []const u8, has_newline: bo
         at_line_start.* = false; // We've processed the line start
     }
 
-    // Write the chunk content with optional special character handling
+    // Write the chunk content with optional special character handling.
+    // When -E is active (without -v), a trailing \r before \n must be
+    // rendered as "^M$" to match GNU cat behavior.
+    const trailing_cr = has_newline and options.show_ends and
+        !options.show_nonprinting and chunk.len > 0 and chunk[chunk.len - 1] == '\r';
+
     if (options.show_tabs or options.show_nonprinting) {
         try writeWithSpecialChars(writer, chunk, options);
+    } else if (trailing_cr) {
+        try writer.writeAll(chunk[0 .. chunk.len - 1]);
+        try writer.writeAll("^M");
     } else {
         try writer.writeAll(chunk);
     }

--- a/src/grep.zig
+++ b/src/grep.zig
@@ -546,8 +546,11 @@ const MatchResult = struct {
     match_end: usize = 0,
 };
 
-/// Check if a line matches a compiled pattern
-fn matchLine(pat: *const CompiledPattern, line: []const u8, allocator: Allocator) MatchResult {
+/// Check if a line matches a compiled pattern.
+/// When word_regexp is true and the pattern is a regex, the match positions
+/// are taken from submatch group 2 (the actual word) rather than group 0
+/// (which includes boundary characters added by the -w wrapping).
+fn matchLine(pat: *const CompiledPattern, line: []const u8, allocator: Allocator, word_regexp: bool) MatchResult {
     switch (pat.*) {
         .fixed => |fp| {
             if (fp.lower) |lower_pattern| {
@@ -566,22 +569,37 @@ fn matchLine(pat: *const CompiledPattern, line: []const u8, allocator: Allocator
         .regex => |re| {
             const line_z = allocator.dupeZ(u8, line) catch return .{ .matched = false };
             defer allocator.free(line_z);
-            var pmatch: [1]c.regmatch_t = undefined;
-            const exec_result = c.regexec(re, line_z.ptr, 1, &pmatch, 0);
-            if (exec_result == 0) {
-                const start: usize = if (pmatch[0].rm_so >= 0) @intCast(pmatch[0].rm_so) else 0;
-                const end: usize = if (pmatch[0].rm_eo >= 0) @intCast(pmatch[0].rm_eo) else 0;
-                return .{ .matched = true, .match_start = start, .match_end = end };
+            if (word_regexp) {
+                // -w wraps pattern as (boundary)(word)(boundary) with 3 groups.
+                // We need group 2 for the actual word match positions.
+                var pmatch: [4]c.regmatch_t = undefined;
+                const exec_result = c.regexec(re, line_z.ptr, 4, &pmatch, 0);
+                if (exec_result == 0) {
+                    // Use group 2 (the word itself) if available, fall back to group 0
+                    const grp: usize = if (pmatch[2].rm_so >= 0) 2 else 0;
+                    const start: usize = if (pmatch[grp].rm_so >= 0) @intCast(pmatch[grp].rm_so) else 0;
+                    const end: usize = if (pmatch[grp].rm_eo >= 0) @intCast(pmatch[grp].rm_eo) else 0;
+                    return .{ .matched = true, .match_start = start, .match_end = end };
+                }
+                return .{ .matched = false };
+            } else {
+                var pmatch: [1]c.regmatch_t = undefined;
+                const exec_result = c.regexec(re, line_z.ptr, 1, &pmatch, 0);
+                if (exec_result == 0) {
+                    const start: usize = if (pmatch[0].rm_so >= 0) @intCast(pmatch[0].rm_so) else 0;
+                    const end: usize = if (pmatch[0].rm_eo >= 0) @intCast(pmatch[0].rm_eo) else 0;
+                    return .{ .matched = true, .match_start = start, .match_end = end };
+                }
+                return .{ .matched = false };
             }
-            return .{ .matched = false };
         },
     }
 }
 
 /// Check if a line matches any of the compiled patterns
-fn matchAnyPattern(patterns: []const CompiledPattern, line: []const u8, allocator: Allocator) MatchResult {
+fn matchAnyPattern(patterns: []const CompiledPattern, line: []const u8, allocator: Allocator, word_regexp: bool) MatchResult {
     for (patterns) |*pat| {
-        const result = matchLine(pat, line, allocator);
+        const result = matchLine(pat, line, allocator, word_regexp);
         if (result.matched) return result;
     }
     return .{ .matched = false };
@@ -712,7 +730,7 @@ fn processFile(
     for (lines.items) |line| {
         line_num += 1;
 
-        const result = matchAnyPattern(patterns, line, allocator);
+        const result = matchAnyPattern(patterns, line, allocator, opts.word_regexp);
         const is_match = if (opts.invert_match) !result.matched else result.matched;
 
         if (is_match) {
@@ -780,7 +798,7 @@ fn processFile(
                         // Advance past this match and search for more
                         search_offset = abs_end;
                         if (search_offset >= line.len) break;
-                        cur_result = matchAnyPattern(patterns, line[search_offset..], allocator);
+                        cur_result = matchAnyPattern(patterns, line[search_offset..], allocator, opts.word_regexp);
                     }
                 } else {
                     if (show_filename) {
@@ -1356,7 +1374,7 @@ test "parseArgs --include and --exclude" {
 
 test "fixed string matching" {
     const pattern = CompiledPattern{ .fixed = .{ .text = "hello", .lower = null } };
-    const result = matchLine(&pattern, "say hello world", testing.allocator);
+    const result = matchLine(&pattern, "say hello world", testing.allocator, false);
     try testing.expect(result.matched);
     try testing.expectEqual(@as(usize, 4), result.match_start);
     try testing.expectEqual(@as(usize, 9), result.match_end);
@@ -1364,7 +1382,7 @@ test "fixed string matching" {
 
 test "fixed string no match" {
     const pattern = CompiledPattern{ .fixed = .{ .text = "xyz", .lower = null } };
-    const result = matchLine(&pattern, "hello world", testing.allocator);
+    const result = matchLine(&pattern, "hello world", testing.allocator, false);
     try testing.expect(!result.matched);
 }
 
@@ -1372,7 +1390,7 @@ test "fixed string case insensitive" {
     const lower = try toLower(testing.allocator, "hello");
     defer testing.allocator.free(lower);
     const pattern = CompiledPattern{ .fixed = .{ .text = "Hello", .lower = lower } };
-    const result = matchLine(&pattern, "say HELLO world", testing.allocator);
+    const result = matchLine(&pattern, "say HELLO world", testing.allocator, false);
     try testing.expect(result.matched);
 }
 
@@ -1402,7 +1420,7 @@ test "regex matching basic" {
     defer c.regfree(regex);
 
     const pattern = CompiledPattern{ .regex = regex };
-    const result = matchLine(&pattern, "say hello world", testing.allocator);
+    const result = matchLine(&pattern, "say hello world", testing.allocator, false);
     try testing.expect(result.matched);
 }
 
@@ -1416,7 +1434,7 @@ test "regex no match" {
     defer c.regfree(regex);
 
     const pattern = CompiledPattern{ .regex = regex };
-    const result = matchLine(&pattern, "hello world", testing.allocator);
+    const result = matchLine(&pattern, "hello world", testing.allocator, false);
     try testing.expect(!result.matched);
 }
 

--- a/src/head.zig
+++ b/src/head.zig
@@ -10,12 +10,14 @@ const HeadArgs = struct {
     help: bool = false,
     /// Output version information and exit
     version: bool = false,
-    /// Number of lines to output (default: 10)
-    lines: ?u64 = null,
+    /// Number of lines to output (default: 10); accepts negative values like "-3"
+    lines: ?[]const u8 = null,
     /// Number of bytes to output (overrides -n)
     bytes: ?u64 = null,
     /// Quiet flag - never print headers
     quiet: bool = false,
+    /// Suppress headers (alias for --quiet)
+    silent: bool = false,
     /// Verbose flag - always print headers
     verbose: bool = false,
     /// Use NUL as line delimiter instead of newline
@@ -28,24 +30,52 @@ const HeadArgs = struct {
         .help = .{ .short = 'h', .desc = "Display this help and exit" },
         .lines = .{ .short = 'n', .desc = "Print the first NUM lines instead of the first 10" },
         .quiet = .{ .short = 'q', .desc = "Never print headers giving file names" },
+        .silent = .{ .short = 0, .desc = "Never print headers giving file names (alias for --quiet)" },
         .verbose = .{ .short = 'v', .desc = "Always print headers giving file names" },
         .version = .{ .short = 'V', .desc = "Output version information and exit" },
         .zero_terminated = .{ .short = 'z', .desc = "Line delimiter is NUL, not newline" },
     };
 };
 
-/// Expand obsolete -NUM syntax (e.g., -5) to -n NUM for backwards compatibility
+/// Expand obsolete -NUM syntax (e.g., -5) to -n NUM for backwards compatibility.
+/// Does not expand -NUM when it follows -n or -c (where it is a value, not obsolete syntax).
 fn expandObsoleteArgs(allocator: std.mem.Allocator, args: []const []const u8) ![]const []const u8 {
     // Count how many extra args we need (one extra per -NUM arg)
     var extra: usize = 0;
+    var prev_expects_value = false;
     for (args) |arg| {
+        if (prev_expects_value) {
+            prev_expects_value = false;
+            continue;
+        }
+        if (std.mem.eql(u8, arg, "-n") or std.mem.eql(u8, arg, "-c") or
+            std.mem.eql(u8, arg, "--lines") or std.mem.eql(u8, arg, "--bytes"))
+        {
+            prev_expects_value = true;
+            continue;
+        }
         if (isObsoleteNumArg(arg)) extra += 1;
     }
     if (extra == 0) return allocator.dupe([]const u8, args);
 
     const expanded = try allocator.alloc([]const u8, args.len + extra);
     var i: usize = 0;
+    prev_expects_value = false;
     for (args) |arg| {
+        if (prev_expects_value) {
+            prev_expects_value = false;
+            expanded[i] = arg;
+            i += 1;
+            continue;
+        }
+        if (std.mem.eql(u8, arg, "-n") or std.mem.eql(u8, arg, "-c") or
+            std.mem.eql(u8, arg, "--lines") or std.mem.eql(u8, arg, "--bytes"))
+        {
+            prev_expects_value = true;
+            expanded[i] = arg;
+            i += 1;
+            continue;
+        }
         if (isObsoleteNumArg(arg)) {
             expanded[i] = "-n";
             i += 1;
@@ -105,13 +135,31 @@ pub fn runHead(allocator: std.mem.Allocator, args: []const []const u8, stdout_wr
         return @intFromEnum(common.ExitCode.success);
     }
 
-    // Create options struct
-    const line_count = parsed_args.lines orelse DEFAULT_LINE_COUNT;
+    // Parse line count, handling negative values (e.g., -n -3 means "all but last 3")
+    var line_count: u64 = DEFAULT_LINE_COUNT;
+    var negative_count: u64 = 0;
+    if (parsed_args.lines) |lines_str| {
+        if (lines_str.len > 0 and lines_str[0] == '-') {
+            // Negative: output all but last N lines
+            negative_count = std.fmt.parseUnsigned(u64, lines_str[1..], 10) catch {
+                common.printErrorWithProgram(allocator, stderr_writer, "head", "invalid number of lines: '{s}'", .{lines_str});
+                return @intFromEnum(common.ExitCode.misuse);
+            };
+        } else {
+            line_count = std.fmt.parseUnsigned(u64, lines_str, 10) catch {
+                common.printErrorWithProgram(allocator, stderr_writer, "head", "invalid number of lines: '{s}'", .{lines_str});
+                return @intFromEnum(common.ExitCode.misuse);
+            };
+        }
+    }
+
+    const is_quiet = parsed_args.quiet or parsed_args.silent;
 
     const options = HeadOptions{
         .line_count = line_count,
+        .negative_count = negative_count,
         .byte_count = parsed_args.bytes,
-        .show_headers = if (parsed_args.quiet) false else if (parsed_args.verbose) true else parsed_args.positionals.len > 1,
+        .show_headers = if (is_quiet) false else if (parsed_args.verbose) true else parsed_args.positionals.len > 1,
         .line_delimiter = if (parsed_args.zero_terminated) 0 else '\n',
     };
 
@@ -121,7 +169,7 @@ pub fn runHead(allocator: std.mem.Allocator, args: []const []const u8, stdout_wr
 
     if (parsed_args.positionals.len == 0) {
         // No files specified, read from stdin
-        try processInput(stdin, stdout_writer, options);
+        try processInput(stdin, stdout_writer, options, allocator);
     } else {
         var had_error = false;
         // Process each file in order
@@ -135,7 +183,7 @@ pub fn runHead(allocator: std.mem.Allocator, args: []const []const u8, stdout_wr
                 if (options.show_headers) {
                     try stdout_writer.writeAll("==> standard input <==\n");
                 }
-                try processInput(stdin, stdout_writer, options);
+                try processInput(stdin, stdout_writer, options, allocator);
             } else {
                 // Open and process regular file
                 const file = std.fs.cwd().openFile(file_path, .{}) catch |err| {
@@ -161,7 +209,7 @@ pub fn runHead(allocator: std.mem.Allocator, args: []const []const u8, stdout_wr
                 }
                 var file_buffer: [8192]u8 = undefined;
                 var file_reader = file.reader(&file_buffer);
-                try processInput(&file_reader.interface, stdout_writer, options);
+                try processInput(&file_reader.interface, stdout_writer, options, allocator);
             }
         }
         if (had_error) {
@@ -226,8 +274,10 @@ fn printVersion(writer: anytype) !void {
 
 /// Options for head behavior
 const HeadOptions = struct {
-    /// Number of lines to output (ignored if byte_count is set)
+    /// Number of lines to output (ignored if byte_count is set or negative_count > 0)
     line_count: u64 = 10,
+    /// When > 0, output all but the last N lines (from -n -N)
+    negative_count: u64 = 0,
     /// Number of bytes to output (overrides line_count if set)
     byte_count: ?u64 = null,
     /// Whether to show file headers
@@ -237,8 +287,51 @@ const HeadOptions = struct {
 };
 
 /// Process input from a reader and output first lines/bytes to writer.
-/// Streams data without reading the entire input into memory.
-pub fn processInput(reader: anytype, writer: anytype, options: HeadOptions) !void {
+/// Streams data without reading the entire input into memory (except for
+/// negative line counts which require buffering the entire input).
+pub fn processInput(reader: anytype, writer: anytype, options: HeadOptions, allocator: ?std.mem.Allocator) !void {
+    if (options.negative_count > 0) {
+        // Negative count: output all but the last N lines.
+        // Must buffer the entire input to know where the last N lines start.
+        const alloc = allocator orelse return;
+        const delimiter = options.line_delimiter;
+        var all_lines = std.ArrayListUnmanaged([]const u8){};
+        defer {
+            for (all_lines.items) |line| alloc.free(line);
+            all_lines.deinit(alloc);
+        }
+        // Read all lines from the reader
+        while (true) {
+            const line = reader.takeDelimiterInclusive(delimiter) catch |err| switch (err) {
+                error.EndOfStream => {
+                    // Handle remaining partial line (no trailing delimiter)
+                    const remaining = reader.buffered();
+                    if (remaining.len > 0) {
+                        const owned = alloc.dupe(u8, remaining) catch return;
+                        all_lines.append(alloc, owned) catch {
+                            alloc.free(owned);
+                            return;
+                        };
+                        reader.toss(remaining.len);
+                    }
+                    break;
+                },
+                else => |e| return e,
+            };
+            const owned = alloc.dupe(u8, line) catch return;
+            all_lines.append(alloc, owned) catch {
+                alloc.free(owned);
+                return;
+            };
+        }
+        // Output all but the last N lines
+        const total = all_lines.items.len;
+        const to_output = if (total > options.negative_count) total - options.negative_count else 0;
+        for (all_lines.items[0..to_output]) |line| {
+            try writer.writeAll(line);
+        }
+        return;
+    }
     if (options.byte_count) |byte_count| {
         // Byte mode: read chunks and write until byte_count reached
         var remaining: u64 = byte_count;


### PR DESCRIPTION
## Summary
- **grep**: Fix `-wo` to output only the matched word, not boundary characters. When `-w` wraps the regex pattern with boundary groups, match positions now come from submatch group 2 (the word) instead of group 0 (the full match including boundary chars).
- **head**: Add `--silent` as alias for `--quiet` (matches GNU coreutils). Implement `-n -N` negative suffix to output all but the last N lines. Fix `expandObsoleteArgs` to not misinterpret `-3` as obsolete `-NUM` syntax when it follows `-n`/`-c`.
- **cat**: When `-E` is active without `-v`, convert trailing `\r` before `\n` to `^M$` to match GNU cat behavior.

## Test plan
- [x] All 4 grep `-wo` audit tests pass (G-03 variants)
- [x] head `--silent` alias test passes
- [x] head `-n -3` negative count test passes
- [x] cat `-E` CRLF tests pass (single line, mid-line CR preserved, multiple CRLF lines)
- [x] No regressions in grep, head, or cat test suites