### PR TITLE
Fix seq, cut, tr integration test failures

### DIFF
--- a/src/cut.zig
+++ b/src/cut.zig
@@ -63,7 +63,7 @@ fn parseRangeList(allocator: Allocator, list_str: []const u8) ![]Range {
     var ranges = std.ArrayListUnmanaged(Range){};
     defer ranges.deinit(allocator);
 
-    var iter = std.mem.tokenizeScalar(u8, list_str, ',');
+    var iter = std.mem.tokenizeAny(u8, list_str, ", ");
     while (iter.next()) |token| {
         const trimmed = std.mem.trim(u8, token, " ");
         if (trimmed.len == 0) continue;

--- a/src/seq.zig
+++ b/src/seq.zig
@@ -475,7 +475,7 @@ pub fn runSeq(allocator: Allocator, args: []const []const u8, stdout_writer: any
         switch (err) {
             error.UnknownFlag => {
                 common.printErrorWithProgram(allocator, stderr_writer, "seq", "unrecognized option", .{});
-                return @intFromEnum(common.ExitCode.general_error);
+                return @intFromEnum(common.ExitCode.misuse);
             },
             error.MissingValue => {
                 common.printErrorWithProgram(allocator, stderr_writer, "seq", "option missing required argument", .{});

--- a/src/tr.zig
+++ b/src/tr.zig
@@ -505,7 +505,7 @@ fn runTrWithInput(
     const max_positionals: usize = if (args.delete and !args.squeeze_repeats) 1 else 2;
     if (args.positionals.len > max_positionals) {
         common.printErrorWithProgram(allocator, stderr_writer, prog_name, "extra operand '{s}'", .{args.positionals[max_positionals]});
-        return @intFromEnum(common.ExitCode.misuse);
+        return @intFromEnum(common.ExitCode.general_error);
     }
 
     // Parse SET1


### PR DESCRIPTION
## Summary
- **seq**: Return exit 2 (misuse) for invalid flags like `--invalid-flag`, matching POSIX convention for argument errors
- **cut**: Accept spaces as range list separators (`-b '1 3 5'`), matching GNU behavior
- **tr**: Return exit 1 (general_error) for extra operands, matching GNU behavior

## Test plan
- [x] `just it-util seq` — 19/19 passed
- [x] `just it-util cut` — 70/70 passed
- [x] `just it-util tr` — 54/54 passed
- [x] `zig build test` — 1984 passed, 27 skipped