### PR TITLE
Fix ls audit findings: -n, -sl, multi-op, errors

### DIFF
--- a/src/ls/formatter.zig
+++ b/src/ls/formatter.zig
@@ -325,6 +325,12 @@ pub fn printLongFormatEntry(allocator: std.mem.Allocator, entry: Entry, writer: 
 
 /// Print a single entry in long format with time column alignment
 fn printLongFormatEntryAligned(allocator: std.mem.Allocator, entry: Entry, writer: anytype, options: LsOptions, style: anytype, max_time_width: usize) !void {
+    // Per-entry block count if -s is active
+    if (options.show_blocks) {
+        const blocks = calculateDisplayBlocks(entry, options);
+        try writer.print("{d: >4} ", .{blocks});
+    }
+
     // Permission string
     var perm_buf: [10]u8 = undefined;
     const perms = if (entry.stat) |stat|
@@ -471,7 +477,7 @@ pub fn printColumnar(allocator: std.mem.Allocator, entries: []Entry, writer: any
     if (options.show_blocks) {
         var max_block_width: usize = 0;
         for (entries) |entry| {
-            max_block_width = @max(max_block_width, blockCountWidth(calculateBlocks(entry)));
+            max_block_width = @max(max_block_width, blockCountWidth(calculateDisplayBlocks(entry, options)));
         }
         block_prefix_width = max_block_width + 1; // block count + space
     }
@@ -503,7 +509,7 @@ pub fn printColumnar(allocator: std.mem.Allocator, entries: []Entry, writer: any
 
             // Print block count prefix if -s
             if (options.show_blocks) {
-                const blocks = calculateBlocks(entry);
+                const blocks = calculateDisplayBlocks(entry, options);
                 // Right-align block count to max_block_width
                 const bw = blockCountWidth(blocks);
                 const pad_count = if (block_prefix_width > bw + 1) block_prefix_width - bw - 1 else 0;
@@ -538,6 +544,17 @@ fn calculateBlocks(entry: Entry) u64 {
     return 0;
 }
 
+/// Calculate display blocks, respecting -k (1024-byte units)
+fn calculateDisplayBlocks(entry: Entry, options: LsOptions) u64 {
+    if (entry.stat) |stat| {
+        if (options.kilobytes) {
+            return (stat.size + 1023) / 1024;
+        }
+        return (stat.size + BLOCK_ROUNDING) / BLOCK_SIZE;
+    }
+    return 0;
+}
+
 /// Print entries in columnar format sorted across rows (-x flag)
 pub fn printColumnarAcross(allocator: std.mem.Allocator, entries: []Entry, writer: anytype, options: LsOptions, style: anytype) !void {
     if (entries.len == 0) return;
@@ -550,7 +567,7 @@ pub fn printColumnarAcross(allocator: std.mem.Allocator, entries: []Entry, write
     if (options.show_blocks) {
         var max_block_width: usize = 0;
         for (entries) |entry| {
-            max_block_width = @max(max_block_width, blockCountWidth(calculateBlocks(entry)));
+            max_block_width = @max(max_block_width, blockCountWidth(calculateDisplayBlocks(entry, options)));
         }
         block_prefix_width = max_block_width + 1; // block count + space
     }
@@ -572,7 +589,7 @@ pub fn printColumnarAcross(allocator: std.mem.Allocator, entries: []Entry, write
     for (entries, 0..) |entry, idx| {
         // Print block count prefix if -s
         if (options.show_blocks) {
-            const blocks = calculateBlocks(entry);
+            const blocks = calculateDisplayBlocks(entry, options);
             const bw = blockCountWidth(blocks);
             const pad_count = if (block_prefix_width > bw + 1) block_prefix_width - bw - 1 else 0;
             for (0..pad_count) |_| {
@@ -611,7 +628,7 @@ pub fn printEntries(
     // Calculate total blocks for -s or -l
     if (options.show_blocks or options.long_format) {
         for (entries) |entry| {
-            total_blocks += calculateBlocks(entry);
+            total_blocks += calculateDisplayBlocks(entry, options);
         }
     }
 
@@ -624,7 +641,7 @@ pub fn printEntries(
         for (entries) |entry| {
             // Print block count if -s
             if (options.show_blocks) {
-                try writer.print("{d: >4} ", .{calculateBlocks(entry)});
+                try writer.print("{d: >4} ", .{calculateDisplayBlocks(entry, options)});
             }
             // Print inode number if requested
             if (options.show_inodes) {

--- a/src/ls/main.zig
+++ b/src/ls/main.zig
@@ -296,7 +296,7 @@ fn lsMain(writer: anytype, stderr_writer: anytype, args: LsArgs, allocator: std.
     const options = LsOptions{
         .all = args.all or args.no_sort,
         .almost_all = args.almost_all,
-        .long_format = args.long_format or args.omit_owner or args.omit_group,
+        .long_format = args.long_format or args.omit_owner or args.omit_group or args.numeric_ids,
         .human_readable = args.human_readable,
         .kilobytes = args.kilobytes,
         .one_per_line = args.one_per_line,
@@ -356,17 +356,57 @@ fn lsMain(writer: anytype, stderr_writer: anytype, args: LsArgs, allocator: std.
     if (paths.len == 0) {
         // No paths specified, list current directory
         try listDirectory(".", writer, stderr_writer, options, allocator, if (git_context) |*ctx| ctx else null);
+    } else if (paths.len == 1) {
+        // Single path: no headers needed
+        listDirectory(paths[0], writer, stderr_writer, options, allocator, if (git_context) |*ctx| ctx else null) catch {
+            had_error = true;
+        };
     } else {
-        // List each specified path
-        // When multiple paths are given, print headers between them
-        for (paths, 0..) |path, i| {
-            if (paths.len > 1) {
-                if (i > 0) try writer.writeAll("\n");
-                try writer.print("{s}:\n", .{path});
+        // Multiple operands: GNU-style separation.
+        // 1. List file operands first (no headers).
+        // 2. List directory operands with "dir:" headers.
+        var file_count: usize = 0;
+        var dir_count: usize = 0;
+
+        for (paths) |path| {
+            const stat = common.file.FileInfo.stat(path) catch {
+                // Errors are handled later during listDirectory
+                dir_count += 1; // count as dir so it gets its own section
+                continue;
+            };
+            if (stat.kind == .directory) {
+                dir_count += 1;
+            } else {
+                file_count += 1;
             }
+        }
+
+        // First pass: list file operands (no headers)
+        for (paths) |path| {
+            const stat = common.file.FileInfo.stat(path) catch continue;
+            if (stat.kind != .directory) {
+                listDirectory(path, writer, stderr_writer, options, allocator, if (git_context) |*ctx| ctx else null) catch {
+                    had_error = true;
+                };
+            }
+        }
+
+        // Second pass: list directory operands with headers
+        var dir_idx: usize = 0;
+        for (paths) |path| {
+            const is_dir = blk: {
+                const stat = common.file.FileInfo.stat(path) catch break :blk true;
+                break :blk stat.kind == .directory;
+            };
+            if (!is_dir) continue;
+
+            // Blank line separator between sections
+            if (file_count > 0 or dir_idx > 0) try writer.writeAll("\n");
+            try writer.print("{s}:\n", .{path});
             listDirectory(path, writer, stderr_writer, options, allocator, if (git_context) |*ctx| ctx else null) catch {
                 had_error = true;
             };
+            dir_idx += 1;
         }
     }
 
@@ -499,18 +539,31 @@ fn printIconTest(writer: anytype) !void {
     try writer.writeAll("  3. Restart your terminal\n");
 }
 
+/// Convert a Zig error to a POSIX-style error string.
+fn posixErrorName(err: anyerror) []const u8 {
+    return switch (err) {
+        error.FileNotFound => "No such file or directory",
+        error.AccessDenied => "Permission denied",
+        error.NotDir => "Not a directory",
+        error.NameTooLong => "File name too long",
+        error.SymLinkLoop => "Too many levels of symbolic links",
+        error.InputOutput => "Input/output error",
+        else => @errorName(err),
+    };
+}
+
 /// List a directory or file, handling both files and directories appropriately
 /// Errors are printed but don't stop execution except for BrokenPipe
 fn listDirectory(path: []const u8, writer: anytype, stderr_writer: anytype, options: LsOptions, allocator: std.mem.Allocator, git_context: ?*types.GitContext) anyerror!void {
     // Initialize style based on color mode
     const style = display.initStyle(allocator, writer, options.color_mode) catch |err| {
-        common.printErrorWithProgram(allocator, stderr_writer, "ls", "failed to initialize styling: {}", .{err});
+        common.printErrorWithProgram(allocator, stderr_writer, "ls", "failed to initialize styling: {s}", .{posixErrorName(err)});
         return err;
     };
 
     // Get stat info to determine if it's a file or directory
     const stat = common.file.FileInfo.stat(path) catch |err| {
-        common.printErrorWithProgram(allocator, stderr_writer, "ls", "{s}: {}", .{ path, err });
+        common.printErrorWithProgram(allocator, stderr_writer, "ls", "{s}: {s}", .{ path, posixErrorName(err) });
         return err;
     };
 
@@ -555,7 +608,7 @@ fn listDirectory(path: []const u8, writer: anytype, stderr_writer: anytype, opti
     }
 
     var dir = std.fs.cwd().openDir(path, .{ .iterate = true }) catch |err| {
-        common.printErrorWithProgram(allocator, stderr_writer, "ls", "{s}: {}", .{ path, err });
+        common.printErrorWithProgram(allocator, stderr_writer, "ls", "{s}: {s}", .{ path, posixErrorName(err) });
         return err;
     };
     defer dir.close();


### PR DESCRIPTION
## Summary
- **-n implies long format**: `-n` now forces long format output, matching GNU spec ("like -l, but list numeric user and group IDs")
- **-sl per-entry block count**: Long format with `-s` now shows per-entry block count before permissions; `-k` uses 1024-byte blocks throughout all display modes
- **Multi-operand file headers**: File operands are listed without headers; only directory operands get `dir:` headers when mixed (GNU behavior)
- **POSIX error messages**: Errors now use POSIX strings ("No such file or directory") instead of Zig error names ("error.FileNotFound")

## Test plan
- [x] `just it-util ls` passes all 77 tests (0 failures)
- [x] `zig build test` passes (full unit test suite)
- [x] `just fmt` clean