### PR TITLE
CI: lint CHANGELOG structure on every PR

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,41 @@
+name: Changelog
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+# Pre-empt the June 2 2026 GitHub Actions Node 24 cutover. Forces all
+# JS-based actions (setup-just, etc.) to run on Node 24 regardless of
+# their action.yml-declared runtime.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+concurrency:
+  group: changelog-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint-changelog:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          # Invariant B diffs each released CHANGELOG section against
+          # its git tag (`git show vX.Y.Z:CHANGELOG.md`), which needs
+          # full tag history — the default shallow checkout has none.
+          fetch-depth: 0
+      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4
+      # Catches the class of bug where a PR merges cleanly (no textual
+      # conflict) but lands unreleased entries inside an already-tagged
+      # section, or drops the "## Unreleased" heading entirely. Git's
+      # line-based merge can't see that a released section is frozen,
+      # so this gate checks it explicitly: Unreleased heading present
+      # (except during the release-promotion window), every released
+      # section byte-identical to its tag, and no leftover conflict
+      # markers.
+      - name: Lint CHANGELOG structure
+        run: just lint-changelog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,13 @@
   failing on any gating violation (oversized function, long line,
   recursion, compound assert, unbounded loop). Available locally as
   `just tiger-check`.
+- **Changelog CI gate.** A `Changelog` workflow lints CHANGELOG.md
+  structure on every PR and push to `main`: the `## Unreleased`
+  heading must be present (except during the release-promotion
+  window), every released `## vX.Y.Z` section must be byte-identical
+  to its git tag, and no merge-conflict markers may remain. Catches
+  clean-but-wrong automerges that file unreleased entries into an
+  already-tagged section. Available locally as `just lint-changelog`.
 
 ## v0.10.3 — 2026-06-29
 

--- a/justfile
+++ b/justfile
@@ -178,6 +178,11 @@ lint-actions:
 tiger-check:
     @./scripts/tiger-check.sh
 
+# Lint CHANGELOG structure: ## Unreleased present, released sections
+# byte-identical to their git tags, no conflict markers.
+lint-changelog:
+    @./scripts/lint-changelog.sh
+
 # Run CI validation checks
 ci-validate:
     zig build ci-validate -Dci=true

--- a/scripts/lint-changelog.sh
+++ b/scripts/lint-changelog.sh
@@ -1,0 +1,165 @@
+#!/bin/sh
+# lint-changelog.sh — structural lint for CHANGELOG.md.
+#
+# WHY: a PR merged cleanly (no textual conflict) but landed
+# unreleased entries inside the already-tagged v0.10.3 section and
+# made the "## Unreleased" heading vanish entirely. Git's line-based
+# merge cannot see that a released section is semantically frozen, so
+# nothing caught it. This script checks the invariants a human editor
+# is expected to hold: an Unreleased heading exists (except during the
+# brief release-promotion window), every released section's text is
+# byte-identical to what was tagged, and no conflict markers remain.
+# Plain POSIX sh + awk/grep, no bashisms; deterministic output; exit 1
+# on any violation, exit 0 clean. Mirrors the house style of
+# scripts/tiger-check.sh.
+
+# Note: intentionally NOT using `set -e`, matching tiger-check.sh — we
+# must run every check to completion and report all violations rather
+# than bailing out on the first non-zero command (e.g. a missing tag).
+set -u
+
+PROG=lint-changelog
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -z "$REPO_ROOT" ]; then
+    echo "$PROG: fatal: not inside a git repository" >&2
+    exit 1
+fi
+
+CHANGELOG="$REPO_ROOT/CHANGELOG.md"
+if [ ! -f "$CHANGELOG" ]; then
+    echo "$PROG: fatal: $CHANGELOG not found" >&2
+    exit 1
+fi
+
+note() {
+    # Human-readable note to stderr only.
+    printf '%s: %s\n' "$PROG" "$*" >&2
+}
+
+# Temp working dir for accumulating violations/verified-count across
+# subshells (pipelines spawn subshells in POSIX sh, so plain shell
+# variables set inside a `| while read` do not survive it; files do).
+WORKDIR=$(mktemp -d "${TMPDIR:-/tmp}/lint-changelog.XXXXXX") || {
+    note "fatal: cannot create temp dir"
+    exit 2
+}
+trap 'rm -rf "$WORKDIR"' EXIT INT TERM
+VIOL_FILE="$WORKDIR/violations"
+VERIFIED_FILE="$WORKDIR/verified"
+: > "$VIOL_FILE"
+: > "$VERIFIED_FILE"
+
+fail() {
+    # Record + print a violation line (contract: violations go to stdout).
+    printf '%s\n' "$*"
+    printf '%s\n' "$*" >> "$VIOL_FILE"
+}
+
+# ---------------------------------------------------------------------------
+# Invariant C: no leftover merge-conflict markers. Checked first since a
+# conflict marker anywhere makes the rest of the file untrustworthy.
+# ---------------------------------------------------------------------------
+grep -nE '^(<<<<<<< |>>>>>>> )' "$CHANGELOG" 2>/dev/null | while IFS= read -r cl; do
+    fail "conflict marker left in CHANGELOG.md: $cl"
+done
+
+# ---------------------------------------------------------------------------
+# Collect every "## " heading line with its line number, in file order.
+# ---------------------------------------------------------------------------
+HEADINGS_FILE="$WORKDIR/headings"
+grep -n '^## ' "$CHANGELOG" > "$HEADINGS_FILE"
+if [ ! -s "$HEADINGS_FILE" ]; then
+    fail "no '## ' heading found in CHANGELOG.md (expected '## Unreleased' first)"
+fi
+
+first_heading=$(head -1 "$HEADINGS_FILE" | cut -d: -f2-)
+
+# ---------------------------------------------------------------------------
+# Invariant A: the first heading must be "## Unreleased", UNLESS it is a
+# just-promoted "## vX.Y.Z — <date>" release heading whose tag does not
+# exist yet (scripts/release.sh rewrites Unreleased to the version
+# heading BEFORE the tag is created).
+# ---------------------------------------------------------------------------
+if [ -n "$first_heading" ]; then
+    if [ "$first_heading" = "## Unreleased" ]; then
+        :
+    else
+        first_version=$(printf '%s\n' "$first_heading" | sed -n 's/^## \(v[0-9][0-9.]*\).*/\1/p')
+        if [ -n "$first_version" ] && ! git -C "$REPO_ROOT" rev-parse -q --verify "refs/tags/$first_version" >/dev/null 2>&1; then
+            note "first heading is '$first_heading' with tag $first_version not yet created; treating as release window"
+        else
+            fail "first '## ' heading must be 'Unreleased', found: $first_heading"
+        fi
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Invariant B: every released section ("## vX.Y.Z — <date>" whose tag
+# exists) must be byte-identical, from its heading line to (not
+# including) the next "## " heading or EOF, in the working tree versus
+# the tagged commit.
+# ---------------------------------------------------------------------------
+total_lines=$(wc -l < "$CHANGELOG" | tr -d ' ')
+heading_lines=$(cut -d: -f1 "$HEADINGS_FILE")
+
+while IFS= read -r start; do
+    [ -n "$start" ] || continue
+    heading_text=$(sed -n "${start}p" "$CHANGELOG")
+    version=$(printf '%s\n' "$heading_text" | sed -n 's/^## \(v[0-9][0-9.]*\).*/\1/p')
+    [ -n "$version" ] || continue
+
+    if ! git -C "$REPO_ROOT" rev-parse -q --verify "refs/tags/$version" >/dev/null 2>&1; then
+        note "skip $version: tag does not exist yet (release window)"
+        continue
+    fi
+
+    # End line: one before the next heading strictly after $start, or EOF.
+    end=$(printf '%s\n' "$heading_lines" | awk -v s="$start" '$1 > s { print $1 - 1; exit }')
+    [ -n "$end" ] || end="$total_lines"
+
+    tagged_file="$WORKDIR/tagged-$version"
+    if ! git -C "$REPO_ROOT" show "$version:CHANGELOG.md" > "$tagged_file" 2>/dev/null; then
+        note "skip $version: git show $version:CHANGELOG.md failed (tag predates the changelog file)"
+        continue
+    fi
+    if [ ! -s "$tagged_file" ]; then
+        note "skip $version: git show $version:CHANGELOG.md failed (tag predates the changelog file)"
+        continue
+    fi
+
+    tagged_start=$(grep -n "^## $version " "$tagged_file" | head -1 | cut -d: -f1)
+    if [ -z "$tagged_start" ]; then
+        note "skip $version: heading not found in tagged CHANGELOG.md"
+        continue
+    fi
+    tagged_total=$(wc -l < "$tagged_file" | tr -d ' ')
+    tagged_end=$(tail -n "+$((tagged_start + 1))" "$tagged_file" | grep -n '^## ' | head -1 | cut -d: -f1)
+    if [ -n "$tagged_end" ]; then
+        tagged_end=$((tagged_start + tagged_end - 1))
+    else
+        tagged_end="$tagged_total"
+    fi
+
+    working_section="$WORKDIR/working-$version"
+    tagged_section="$WORKDIR/section-$version"
+    sed -n "${start},${end}p" "$CHANGELOG" > "$working_section"
+    sed -n "${tagged_start},${tagged_end}p" "$tagged_file" > "$tagged_section"
+
+    if ! cmp -s "$working_section" "$tagged_section"; then
+        fail "released section '$version' differs from its tag ($version) — released sections are immutable:"
+        diff -u "$tagged_section" "$working_section"
+    else
+        printf '%s\n' "$version" >> "$VERIFIED_FILE"
+    fi
+done <<EOF
+$heading_lines
+EOF
+
+VIOLATIONS=$(wc -l < "$VIOL_FILE" | tr -d ' ')
+VERIFIED_COUNT=$(wc -l < "$VERIFIED_FILE" | tr -d ' ')
+
+if [ "$VIOLATIONS" -gt 0 ]; then
+    exit 1
+fi
+printf '%s: OK (%s released sections verified)\n' "$PROG" "$VERIFIED_COUNT"
+exit 0


### PR DESCRIPTION
The Tiger Style merge (#49) automerged CHANGELOG.md cleanly but
semantically wrong: unreleased entries landed inside the already-tagged
v0.10.3 section and the `## Unreleased` heading vanished (fixed in
dbcfdde). Git's line-based merge can't know a released section is
frozen, and no hook runs on GitHub's server-side merge commit, so
nothing caught it.

## What this adds

**`scripts/lint-changelog.sh`** (POSIX sh, tiger-check house style)
enforcing three invariants:

1. The first `## ` heading is `Unreleased` — except during the
   release-promotion window, when the just-promoted `## vX.Y.Z`
   heading legitimately has no tag yet, so this never blocks
   `just release`.
2. Every released `## vX.Y.Z` section is byte-identical to that
   section in its `vX.Y.Z` tag (released sections are immutable).
   This catches the #49 incident class exactly, with a `diff -u`
   against the tag on failure.
3. No leftover merge-conflict markers.

**`.github/workflows/changelog.yml`** — runs the lint on every PR and
push to `main` (`fetch-depth: 0` for tag access; same pinned action
SHAs as the Tiger Style workflow).

**`just lint-changelog`** — local parity recipe.

## Verification

- Green on the current repo: `OK (4 released sections verified)`
  (v0.10.0–v0.10.3; older tags predate CHANGELOG.md and are skipped
  with a note; the untagged v0.8.4 section is skipped gracefully).
- All three invariants sabotage-tested: heading rename, a byte
  mutated inside the tagged v0.10.3 section, and injected conflict
  markers each fail with the right message and exit 1; restored file
  returns to green.
- `shellcheck -s sh` clean; POSIX-portable grep (no GNU `\|`
  alternation, works on macOS BSD grep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PY3sQRcvisJFbi32Nuo1Nu

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and shell lint only; no runtime or application code paths change.
> 
> **Overview**
> Adds a **Changelog CI gate** so clean automerges cannot silently corrupt `CHANGELOG.md` (e.g. unreleased bullets ending up inside an already-tagged section or losing `## Unreleased`).
> 
> **`scripts/lint-changelog.sh`** (POSIX sh, same style as `tiger-check`) enforces: no conflict markers; the first `##` heading is `## Unreleased` except during release promotion when the top version tag is not created yet; every tagged `## vX.Y.Z` block matches that section in `git show vX.Y.Z:CHANGELOG.md`, with `diff -u` on failure.
> 
> **`.github/workflows/changelog.yml`** runs `just lint-changelog` on PRs and pushes to `main`, with `fetch-depth: 0` for tag comparisons and the same pinned actions / Node 24 env as the Tiger Style workflow. **`just lint-changelog`** mirrors CI locally. **Unreleased** in `CHANGELOG.md` documents the new gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4244445213cc94a4532d5fbe8e801370c2249555. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->