### PR TITLE
Halt walk on EntryLimitExceeded in grep and mv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## Unreleased
 
 ### Fixed
+- **grep `-r` and mv now halt cleanly at the walker entry cap.**
+  Hitting the 16M-entry safety cap previously re-fired the same
+  error on every subsequent iteration, an infinite storm of
+  identical diagnostics; the cap is now reported once, the walk
+  stops, and the usual error exit status is preserved.
 - **grep `-R` now descends symbolic links to directories.**
   Following a directory symlink under `-R` previously did nothing
   (opening the symlink read-only succeeded, so grep treated it as a

--- a/src/grep.zig
+++ b/src/grep.zig
@@ -1848,6 +1848,9 @@ fn searchTree(
             // An unreadable directory (or other per-entry I/O failure) is
             // non-fatal: report it and let the walker resume at siblings.
             reportWalkError(io, root_path, err, opts, stderr_writer, &search);
+            // The entry-count cap is terminal: next() latches this error and
+            // re-returns it forever, so stop the walk instead of spinning.
+            if (err == error.EntryLimitExceeded) break;
             continue;
         };
         const entry = maybe_entry orelse break;

--- a/src/grep.zig
+++ b/src/grep.zig
@@ -1819,6 +1819,7 @@ fn searchTree(
     stderr_writer: *std.Io.Writer,
     use_color: bool,
     found_any: *bool,
+    walk_config: common.walker.WalkConfig,
 ) void {
     assert(root_path.len > 0);
     // Cannot split: "or" means either flag suffices, not both.
@@ -1826,11 +1827,7 @@ fn searchTree(
 
     var search = TreeSearch{
         .allocator = allocator,
-        .walker = common.walker.Walker.init(allocator, .{
-            .order = .pre,
-            .symlinks = .no_follow,
-            .detect_cycles = false,
-        }) catch return,
+        .walker = common.walker.Walker.init(allocator, walk_config) catch return,
         .visited_dirs = if (opts.dereference_recursive)
             common.directory.FileSystemIdSet.init(allocator)
         else
@@ -2322,6 +2319,7 @@ fn runGrep_dispatchInputs(d: DispatchInputs) bool {
             d.stderr_writer,
             d.use_color,
             d.found_any_ptr,
+            .{ .order = .pre, .symlinks = .no_follow, .detect_cycles = false },
         );
     } else {
         for (opts.files.items) |file_path| {
@@ -2449,6 +2447,7 @@ fn runGrep_processOneOperand(
                 stderr_writer,
                 use_color,
                 found_any_ptr,
+                .{ .order = .pre, .symlinks = .no_follow, .detect_cycles = false },
             );
             return false;
         }
@@ -4322,4 +4321,74 @@ test "walker-migration: traversal entry point is the bounded walker after migrat
         try testing.expect(@hasDecl(common.walker.Walker, "next"));
         try testing.expect(@hasDecl(common.walker.Walker, "addRoot"));
     }
+}
+
+test "searchTree halts once on EntryLimitExceeded instead of looping (issue #45)" {
+    // Regression for issue #45. The bounded walker's entry cap is PERMANENT:
+    // once entries_emitted >= max_entries, walker.next() returns
+    // error.EntryLimitExceeded on EVERY subsequent call. The pre-fix searchTree
+    // loop reported that error and `continue`d, so it re-hit the permanent cap
+    // forever — a genuine infinite loop (a diagnostics storm, not a clean halt).
+    //
+    // Methodology: drive the REAL searchTree with a tiny max_entries (injected
+    // through the walk_config seam; production keeps the 1<<24 default) against a
+    // tree that exceeds the cap, and require it to (a) return at all and (b)
+    // report the entry-limit condition EXACTLY once. Pre-fix the call never
+    // returns, so an external wall-clock timeout must catch the run — that hang
+    // IS the RED evidence, because control never comes back to check an assert.
+    const io = testing.io;
+
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    // Ten flat files guarantee the pre-order walk (root dir + files) blows past
+    // a max_entries=3 cap while entries remain, so the permanent cap re-fires.
+    inline for (.{
+        "f01.txt", "f02.txt", "f03.txt", "f04.txt", "f05.txt",
+        "f06.txt", "f07.txt", "f08.txt", "f09.txt", "f10.txt",
+    }) |name| {
+        const f = try tmp.dir.createFile(io, name, .{});
+        try f.writeStreamingAll(io, "needle\n");
+        f.close(io);
+    }
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    var root_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const root_len = try tmp.dir.realPath(io, &root_buf);
+    const root = try allocator.dupe(u8, root_buf[0..root_len]);
+
+    const patterns = [_]CompiledPattern{
+        .{ .fixed = .{ .text = "needle", .lower = null } },
+    };
+    const opts = GrepOptions{ .recursive = true };
+
+    // Capture stderr in a FIXED buffer so a pre-fix storm cannot grow memory
+    // without bound: once the buffer fills, further writes fail silently and the
+    // loop just spins — a clean hang for the timeout to catch. One entry-limit
+    // diagnostic fits easily in 4 KiB post-fix.
+    var stderr_buf: [4096]u8 = undefined;
+    var stderr_w: std.Io.Writer = .fixed(&stderr_buf);
+
+    var found_any = false;
+    searchTree(
+        allocator,
+        io,
+        root,
+        &patterns,
+        &opts,
+        common.null_writer,
+        &stderr_w,
+        false,
+        &found_any,
+        .{ .order = .pre, .symlinks = .no_follow, .detect_cycles = false, .max_entries = 3 },
+    );
+
+    // Returning here at all is the core regression proof: the walk halted
+    // instead of spinning. The entry-limit error must be reported EXACTLY once
+    // (report-then-break), not once per remaining entry.
+    const reported = std.mem.count(u8, stderr_w.buffered(), "EntryLimitExceeded");
+    try testing.expectEqual(@as(usize, 1), reported);
 }

--- a/src/mv.zig
+++ b/src/mv.zig
@@ -580,6 +580,7 @@ fn crossFilesystemMove(
             options,
             stdout_writer,
             stderr_writer,
+            .{ .order = .both, .symlinks = .no_follow, .detect_cycles = true },
         );
     } else {
         errdefer std.Io.Dir.cwd().deleteFile(io, dest) catch {};
@@ -674,15 +675,11 @@ fn copyDirectoryTree(
     options: MoveOptions,
     stdout_writer: anytype,
     stderr_writer: anytype,
+    walk_config: common.walker.WalkConfig,
 ) !void {
     assert(source.len > 0);
     assert(dest.len > 0);
 
-    const walk_config = common.walker.WalkConfig{
-        .order = .both,
-        .symlinks = .no_follow,
-        .detect_cycles = true,
-    };
     var dir_walker = try common.walker.Walker.init(allocator, walk_config);
     defer dir_walker.deinit(io);
     try dir_walker.addRoot(source);
@@ -2974,4 +2971,56 @@ test "walker-migration: cross-device fallback continues past unreadable subdir (
     _ = std.c.chmod(locked_path_z, 0o755);
     try testing.expect(test_dir.fileExists("src/locked"));
     try test_dir.inner.expectFileContent("src/open/f.txt", "open body");
+}
+
+test "copyDirectoryTree halts on EntryLimitExceeded instead of looping (issue #45)" {
+    // Regression for issue #45 (mv side). Same permanent-cap bug as grep: once
+    // the bounded walker trips max_entries, walker.next() returns
+    // error.EntryLimitExceeded on every subsequent call. The pre-fix
+    // copyDirectoryTree loop reported via recoverDescendError and `continue`d,
+    // so it re-hit the permanent cap forever — an infinite loop.
+    //
+    // Methodology: inject a tiny max_entries through the walk_config seam
+    // (production keeps the 1<<24 default) against a tree that exceeds the cap,
+    // and require the copy to RETURN promptly with error.SomeCopyFailed rather
+    // than spin. Pre-fix the call never returns; that hang, caught by an
+    // external wall-clock timeout, is the RED evidence.
+    const io = testing.io;
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    var test_dir = TestDir.init(allocator);
+    defer test_dir.deinit();
+
+    // A source tree with well over three entries so the .both walk blows past a
+    // max_entries=3 cap while entries remain, making the permanent cap re-fire.
+    try test_dir.inner.createDir("src");
+    inline for (.{ "f01", "f02", "f03", "f04", "f05", "f06" }) |name| {
+        try test_dir.createFile("src/" ++ name ++ ".txt", "body\n");
+    }
+
+    const base_path = try test_dir.inner.getBasePath();
+    const source = try std.fmt.allocPrint(allocator, "{s}/src", .{base_path});
+    const dest = try std.fmt.allocPrint(allocator, "{s}/dst", .{base_path});
+
+    // Fixed stderr buffer so any pre-fix diagnostics storm stays bounded and the
+    // loop degrades to a pure spin — a clean hang for the timeout to catch.
+    var stderr_buf: [4096]u8 = undefined;
+    var stderr_w: std.Io.Writer = .fixed(&stderr_buf);
+
+    // Post-fix: the catch arm sets had_copy_error then breaks, so the tree copy
+    // returns error.SomeCopyFailed. Pre-fix: never returns (infinite loop).
+    const result = copyDirectoryTree(
+        allocator,
+        io,
+        source,
+        dest,
+        .{},
+        common.null_writer,
+        &stderr_w,
+        .{ .order = .both, .symlinks = .no_follow, .detect_cycles = true, .max_entries = 3 },
+    );
+    try testing.expectError(error.SomeCopyFailed, result);
 }

--- a/src/mv.zig
+++ b/src/mv.zig
@@ -686,9 +686,9 @@ fn copyDirectoryTree(
 
     var had_copy_error = false;
     // The bounded walker drives termination: next() yields null when the
-    // traversal is exhausted (the `orelse break` below), and a per-entry error
-    // drives `continue`, so only exhaustion ends this loop. No numeric cap: the
-    // tree depth/breadth is unbounded a priori and a cap would truncate it.
+    // traversal is exhausted (the `orelse break` below); a per-entry error
+    // drives `continue`; and a terminal cap error (EntryLimitExceeded) breaks,
+    // since next() latches it and would otherwise re-fire forever.
     while (true) { // tiger:allow:unbounded-loop terminates when walker.next() returns null
         const maybe_entry = dir_walker.next(io) catch |err| {
             // A per-entry error (e.g. opening an unreadable subdir) is reported
@@ -696,6 +696,9 @@ fn copyDirectoryTree(
             // failing child path on error, so recover it from the parent.
             recoverDescendError(allocator, io, &dir_walker, source, dest, stderr_writer, err);
             had_copy_error = true;
+            // The entry-count cap is terminal: next() latches this error and
+            // re-returns it forever, so stop the walk instead of spinning.
+            if (err == error.EntryLimitExceeded) break;
             continue;
         };
         const entry = maybe_entry orelse break;


### PR DESCRIPTION
## Summary
`walker.next()` latches `error.EntryLimitExceeded` permanently once `entries_emitted >= max_entries`. The catch arms in `searchTree` (grep) and `copyDirectoryTree` (mv) reported the error then `continue`d, immediately re-hitting the latched error — an infinite storm of identical errors instead of a single clean halt. The cap is now terminal: report once, keep the error-flag semantics (grep exit status / mv `SomeCopyFailed`), then break.

A `walk_config` seam on both functions lets tests inject a small `max_entries`; production call sites pass their previous hardcoded configs byte-for-byte (verified in review), so production behavior is unchanged at 1<<24.

## TDD evidence
- RED (28cb1d7): both regression tests hang in the recover-and-continue loop on unfixed code (`timeout` exit 124); everything else green with them skipped.
- GREEN (0c6f033): `zig build test --summary all` pass; `just it` 48/48 utilities; `just it-util grep` 59/59; `just it-util mv` 110 pass/1 skip.
- Other walker callers audited: find, chmod, du already treat the cap as terminal.

## Adversarial review
Approved (no blocking findings). Minor notes recorded for follow-up, none introduced by this change: grep exits 0/1 rather than GNU's 2 on walk errors (pre-existing, all walk errors); `recoverDescendError` misdiagnoses the cap error (seam-only reachable); a regression of this fix manifests as a CI hang bounded by the 30-min job timeout rather than a fast failure.

Closes #45.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fqscf2s7jmDAEEybsRH6qt

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted loop-control change with tests; production walker config is unchanged and other utilities already break on the same cap.
> 
> **Overview**
> Fixes **issue #45**: when recursive **grep** or **mv** hit the bounded walker's **16M-entry cap**, `walker.next()` keeps returning **`error.EntryLimitExceeded`**. The walk loops reported the error and **`continue`d**, causing an endless storm of identical diagnostics (or a hang) instead of stopping once.
> 
> **grep** `searchTree` and **mv** `copyDirectoryTree` now treat **`EntryLimitExceeded` as terminal**: report once, then **`break`** the walk. Existing failure semantics stay the same (grep's error exit path / mv **`SomeCopyFailed`**).
> 
> Both functions take an injected **`walk_config`** so tests can use a tiny **`max_entries`**; production call sites pass the same walker settings as before (default cap unchanged).
> 
> Regression unit tests assert the walk **returns** and the entry-limit message appears **exactly once** on stderr. **CHANGELOG** documents the user-visible fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b9dd7ff5c500ea1282b122b26afba8a6ce02e41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->