### PR TITLE
realpath: resolve non-absolute paths in one place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 ## Unreleased
 
 ### Fixed
+- **realpath no longer aborts on relative or empty path inputs.**
+  An empty or relative `--relative-to=`/`--relative-base=` value,
+  an empty `-e` operand, or a relative `-e` operand tripped a
+  std-library assertion and killed the process (SIGABRT, exit
+  134). Relative paths now resolve against the working directory
+  and empty paths report `No such file or directory` with exit 1,
+  matching GNU.
 - **grep `-r` and mv now halt cleanly at the walker entry cap.**
   Hitting the 16M-entry safety cap previously re-fired the same
   error on every subsequent iteration, an infinite storm of

--- a/src/realpath.zig
+++ b/src/realpath.zig
@@ -10,13 +10,28 @@ const path_utils = common.path;
 const testing = std.testing;
 const Allocator = std.mem.Allocator;
 
-/// Resolve an absolute path to its canonical form, returning a heap-allocated
-/// `[]u8` (not sentinel-terminated). Using a stack buffer + `allocator.dupe`
-/// avoids the debug-allocator size mismatch from `realPathFileAbsoluteAlloc`
-/// returning `[:0]u8` which when freed as `[]u8` reports the wrong size.
-fn realPathAbsoluteDupe(allocator: Allocator, io: std.Io, path: []const u8) ![]u8 {
+/// Resolve a path to its canonical form, returning a heap-allocated `[]u8` (not
+/// sentinel-terminated). Handles all three input classes: an empty path is
+/// rejected as ENOENT (GNU parity), while relative and absolute paths both route
+/// through `cwd().realPathFile`. Using a stack buffer + `allocator.dupe` avoids
+/// the debug-allocator size mismatch from `realPathFileAbsoluteAlloc` returning
+/// `[:0]u8` which when freed as `[]u8` reports the wrong size.
+fn realPathDupe(allocator: Allocator, io: std.Io, path: []const u8) ![]u8 {
+    // GNU realpath reports "No such file or directory" for an empty operand
+    // rather than treating it as the cwd. Rejecting it here also keeps it away
+    // from realPathFileAbsolute, whose isAbsolute assert would abort the process.
+    if (path.len == 0) {
+        return error.FileNotFound;
+    }
+    std.debug.assert(path.len > 0);
+
+    // cwd().realPathFile resolves absolute paths (the dir handle is ignored) and
+    // paths relative to the cwd, without asserting isAbsolute. Avoid
+    // cwd().realPath (issue #51: broken under Threaded io; readlinks AT_FDCWD).
     var buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
-    const len = try std.Io.Dir.realPathFileAbsolute(io, path, &buf);
+    const len = try std.Io.Dir.cwd().realPathFile(io, path, &buf);
+    std.debug.assert(len > 0);
+    std.debug.assert(len <= buf.len);
     return allocator.dupe(u8, buf[0..len]);
 }
 
@@ -165,7 +180,7 @@ fn processPath_resolveTarget(
         };
     } else if (opts.canonicalize_existing) {
         // -e: all components must exist
-        return realPathAbsoluteDupe(allocator, io, path) catch |err| {
+        return realPathDupe(allocator, io, path) catch |err| {
             if (!opts.quiet) {
                 printResolveError(allocator, stderr_writer, path, err);
             }
@@ -183,7 +198,8 @@ fn processPath_resolveTarget(
 }
 
 /// Resolve the relative base directory. Distinct from `processPath_resolveTarget`:
-/// the default branch uses `realPathAbsoluteDupe` (no parent-must-exist mode).
+/// the default branch uses `realPathDupe` (no parent-must-exist mode). An empty
+/// base surfaces as ENOENT via `realPathDupe`, matching GNU realpath.
 /// Returns the owned resolved slice, or null when an error was already reported.
 fn processPath_resolveBase(
     allocator: Allocator,
@@ -207,7 +223,7 @@ fn processPath_resolveBase(
             return null;
         };
     } else {
-        return realPathAbsoluteDupe(allocator, io, base_dir) catch |err| {
+        return realPathDupe(allocator, io, base_dir) catch |err| {
             if (!opts.quiet) {
                 printResolveError(allocator, stderr_writer, base_dir, err);
             }

--- a/src/realpath.zig
+++ b/src/realpath.zig
@@ -1095,6 +1095,173 @@ test "realpath: empty --relative-base= errors instead of panicking" {
 }
 
 // ============================================================================
+// Issue #46 (round 2): non-absolute paths must be resolved, not forwarded raw
+// to realPathFileAbsolute (which asserts isAbsolute and aborts the process).
+// The round-1 fix only guarded the EMPTY base in processPath_resolveBase; these
+// pin the still-uncovered cases: a relative (but non-empty) base, an empty
+// target operand, and a relative target operand.
+// ============================================================================
+
+// A RELATIVE --relative-to base must be resolved against the cwd. Before the
+// fix the default (symlink-following) base branch calls realPathAbsoluteDupe(".")
+// -> realPathFileAbsolute, which asserts isAbsolute and aborts (SIGABRT / exit
+// 134), killing the in-process test runner. GNU prints the target relative to
+// the resolved base. We chdir into a tmp dir so "." is deterministic and does
+// not depend on the repo cwd; the cwd handle is restored via fchdir on exit.
+test "realpath: relative --relative-to=. resolves against cwd (issue #46)" {
+    const io = testing.io;
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    try tmp_dir.dir.createDirPath(io, "sub");
+
+    var saved_cwd_dir = try std.Io.Dir.cwd().openDir(io, ".", .{});
+    defer {
+        std.process.setCurrentDir(io, saved_cwd_dir) catch {};
+        saved_cwd_dir.close(io);
+    }
+
+    const tmp_abs = try tmp_dir.dir.realPathFileAlloc(io, ".", testing.allocator);
+    defer testing.allocator.free(tmp_abs);
+
+    try std.Io.Threaded.chdir(tmp_abs);
+
+    // Absolute target under the resolved base; expected relative form is "sub".
+    const target = try std.fmt.allocPrint(testing.allocator, "{s}/sub", .{tmp_abs});
+    defer testing.allocator.free(target);
+
+    var stdout_aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer stdout_aw.deinit();
+    var stderr_aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer stderr_aw.deinit();
+
+    const args = [_][]const u8{ "--relative-to=.", target };
+    const result = try runRealpath(
+        testing.allocator,
+        io,
+        &args,
+        &stdout_aw.writer,
+        &stderr_aw.writer,
+    );
+
+    try testing.expectEqual(@as(u8, 0), result);
+    try testing.expectEqualStrings("sub\n", stdout_aw.writer.buffered());
+}
+
+// A RELATIVE --relative-base value hits the same crashing default branch of
+// processPath_resolveBase. GNU resolves the base against the cwd and, since the
+// target is under it, prints the relative form ("child").
+test "realpath: relative --relative-base=sub resolves against cwd (issue #46)" {
+    const io = testing.io;
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    try tmp_dir.dir.createDirPath(io, "sub/child");
+
+    var saved_cwd_dir = try std.Io.Dir.cwd().openDir(io, ".", .{});
+    defer {
+        std.process.setCurrentDir(io, saved_cwd_dir) catch {};
+        saved_cwd_dir.close(io);
+    }
+
+    const tmp_abs = try tmp_dir.dir.realPathFileAlloc(io, ".", testing.allocator);
+    defer testing.allocator.free(tmp_abs);
+
+    try std.Io.Threaded.chdir(tmp_abs);
+
+    const target = try std.fmt.allocPrint(testing.allocator, "{s}/sub/child", .{tmp_abs});
+    defer testing.allocator.free(target);
+
+    var stdout_aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer stdout_aw.deinit();
+    var stderr_aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer stderr_aw.deinit();
+
+    const args = [_][]const u8{ "--relative-base=sub", target };
+    const result = try runRealpath(
+        testing.allocator,
+        io,
+        &args,
+        &stdout_aw.writer,
+        &stderr_aw.writer,
+    );
+
+    try testing.expectEqual(@as(u8, 0), result);
+    try testing.expectEqualStrings("child\n", stdout_aw.writer.buffered());
+}
+
+// An empty TARGET operand under -e reaches processPath_resolveTarget's
+// canonicalize_existing branch, which the round-1 base guard does not cover.
+// realPathAbsoluteDupe("") aborts on the isAbsolute assert; GNU reports ENOENT.
+test "realpath: -e with empty operand errors instead of panicking (issue #46)" {
+    const io = testing.io;
+    var stdout_aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer stdout_aw.deinit();
+    var stderr_aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer stderr_aw.deinit();
+
+    const args = [_][]const u8{ "-e", "" };
+    const result = try runRealpath(
+        testing.allocator,
+        io,
+        &args,
+        &stdout_aw.writer,
+        &stderr_aw.writer,
+    );
+
+    try testing.expectEqual(@as(u8, 1), result);
+    try testing.expectEqual(@as(usize, 0), stdout_aw.writer.buffered().len);
+    const err_out = stderr_aw.writer.buffered();
+    try testing.expect(err_out.len > 0);
+    try testing.expect(std.mem.find(u8, err_out, "No such file or directory") != null);
+}
+
+// A RELATIVE existing TARGET under -e must be resolved to its absolute canonical
+// path. Before the fix realPathAbsoluteDupe("existing.txt") aborts on the
+// isAbsolute assert. GNU prints the absolute resolved path and exits 0.
+test "realpath: -e resolves a relative existing file to an absolute path (issue #46)" {
+    const io = testing.io;
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    {
+        const file = try tmp_dir.dir.createFile(io, "existing.txt", .{});
+        file.close(io);
+    }
+
+    var saved_cwd_dir = try std.Io.Dir.cwd().openDir(io, ".", .{});
+    defer {
+        std.process.setCurrentDir(io, saved_cwd_dir) catch {};
+        saved_cwd_dir.close(io);
+    }
+
+    const tmp_abs = try tmp_dir.dir.realPathFileAlloc(io, ".", testing.allocator);
+    defer testing.allocator.free(tmp_abs);
+
+    try std.Io.Threaded.chdir(tmp_abs);
+
+    const expected = try std.fmt.allocPrint(testing.allocator, "{s}/existing.txt\n", .{tmp_abs});
+    defer testing.allocator.free(expected);
+
+    var stdout_aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer stdout_aw.deinit();
+    var stderr_aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer stderr_aw.deinit();
+
+    const args = [_][]const u8{ "-e", "existing.txt" };
+    const result = try runRealpath(
+        testing.allocator,
+        io,
+        &args,
+        &stdout_aw.writer,
+        &stderr_aw.writer,
+    );
+
+    try testing.expectEqual(@as(u8, 0), result);
+    try testing.expectEqualStrings(expected, stdout_aw.writer.buffered());
+}
+
+// ============================================================================
 // E7: Behavioral tests — all-but-last-exist semantics (GNU default mode)
 // ============================================================================
 

--- a/src/realpath.zig
+++ b/src/realpath.zig
@@ -1040,6 +1040,61 @@ test "realpath: --relative-to without -s resolves existing paths" {
 }
 
 // ============================================================================
+// Issue #46: empty --relative-to= / --relative-base= base must error, not panic
+// ============================================================================
+
+// An empty --relative-to= value must produce a clean error (exit 1) matching
+// GNU realpath ("realpath: '': No such file or directory"), not an
+// unreachable-code panic from realPathFileAbsolute asserting isAbsolute.
+test "realpath: empty --relative-to= errors instead of panicking" {
+    const io = testing.io;
+    var stdout_aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer stdout_aw.deinit();
+    var stderr_aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer stderr_aw.deinit();
+
+    const args = [_][]const u8{ "--relative-to=", "/tmp" };
+    const result = try runRealpath(
+        testing.allocator,
+        io,
+        &args,
+        &stdout_aw.writer,
+        &stderr_aw.writer,
+    );
+
+    try testing.expectEqual(@as(u8, 1), result);
+    try testing.expectEqual(@as(usize, 0), stdout_aw.writer.buffered().len);
+    const err_out = stderr_aw.writer.buffered();
+    try testing.expect(err_out.len > 0);
+    try testing.expect(std.mem.find(u8, err_out, "No such file or directory") != null);
+}
+
+// Same guard for the --relative-base= spelling: an empty base must not be
+// forwarded to realPathFileAbsolute (which asserts an absolute path).
+test "realpath: empty --relative-base= errors instead of panicking" {
+    const io = testing.io;
+    var stdout_aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer stdout_aw.deinit();
+    var stderr_aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer stderr_aw.deinit();
+
+    const args = [_][]const u8{ "--relative-base=", "/tmp" };
+    const result = try runRealpath(
+        testing.allocator,
+        io,
+        &args,
+        &stdout_aw.writer,
+        &stderr_aw.writer,
+    );
+
+    try testing.expectEqual(@as(u8, 1), result);
+    try testing.expectEqual(@as(usize, 0), stdout_aw.writer.buffered().len);
+    const err_out = stderr_aw.writer.buffered();
+    try testing.expect(err_out.len > 0);
+    try testing.expect(std.mem.find(u8, err_out, "No such file or directory") != null);
+}
+
+// ============================================================================
 // E7: Behavioral tests — all-but-last-exist semantics (GNU default mode)
 // ============================================================================
 

--- a/tests/utilities/realpath_test.sh
+++ b/tests/utilities/realpath_test.sh
@@ -357,4 +357,42 @@ test_realpath() {
             "Expected 'subdir/file.txt', got '$rel_out'"
     fi
     rm -rf "$rel_dir"
+
+    # Issue #46: a RELATIVE --relative-to base must be resolved against the cwd,
+    # not forwarded verbatim to realPathFileAbsolute (which asserts isAbsolute
+    # and aborts with SIGABRT / exit 134). GNU prints the target relative to the
+    # resolved base. We cd into a tmp dir so "." is deterministic.
+    echo -e "${CYAN}Testing relative --relative-to base (issue #46)...${NC}"
+
+    local rel_base_dir="$TEMP_DIR/realpath_rel_base_test"
+    mkdir -p "$rel_base_dir/sub"
+
+    local rel_base_out rel_base_rc
+    rel_base_out=$(cd "$rel_base_dir" && "$binary" --relative-to=. "$rel_base_dir/sub" 2>/dev/null)
+    rel_base_rc=$?
+    if [[ "$rel_base_rc" -eq 0 && "$rel_base_out" == "sub" ]]; then
+        print_test_result "relative --relative-to=. resolves against cwd" "PASS"
+    else
+        print_test_result "relative --relative-to=. resolves against cwd" "FAIL" \
+            "Expected exit 0 and 'sub', got exit=$rel_base_rc out='$rel_base_out'"
+    fi
+    rm -rf "$rel_base_dir"
+
+    # Issue #46: an empty --relative-to= value must produce a clean ENOENT error
+    # (exit 1), never a SIGABRT (exit 134) from the isAbsolute assert.
+    local empty_rt_err empty_rt_rc
+    empty_rt_err=$("$binary" --relative-to= /tmp 2>&1 >/dev/null)
+    empty_rt_rc=$?
+    if [[ "$empty_rt_rc" -eq 1 ]]; then
+        print_test_result "empty --relative-to= exits 1 (not 134)" "PASS"
+    else
+        print_test_result "empty --relative-to= exits 1 (not 134)" "FAIL" \
+            "Expected exit 1, got $empty_rt_rc"
+    fi
+    if [[ "$empty_rt_err" == *"No such file or directory"* ]]; then
+        print_test_result "empty --relative-to= reports No such file or directory" "PASS"
+    else
+        print_test_result "empty --relative-to= reports No such file or directory" "FAIL" \
+            "Error: $empty_rt_err"
+    fi
 }


### PR DESCRIPTION
## Summary
`realpath --relative-to= /tmp` (and `--relative-base=`) aborted with SIGABRT: the empty base reached `std.Io.Dir.realPathFileAbsolute`, which asserts `isAbsolute`. Adversarial review widened the scope to the whole crash class: any *relative* base (`--relative-to=.` is the flag's most common use), an empty `-e` operand, and a relative `-e` operand all tripped the same assert.

The fix is at the root: `realPathAbsoluteDupe` is renamed to `realPathDupe` and now rejects empty input as ENOENT (GNU parity: exit 1, `No such file or directory`) and resolves relative and absolute paths via `cwd().realPathFile` — the variant unaffected by the #51 `cwd().realPath` breakage. Both callers share it.

## TDD evidence
- RED round 1 (fea577e): empty-base tests SIGABRT through the exact assert.
- RED round 2 (15d4a4b): relative-base / empty `-e` / relative `-e` tests all SIGABRT through the same assert; reviewer independently reproduced red from a staged-only reconstruction.
- GREEN (694bea3): 45/45 realpath unit tests (was 41 pass + 4 crash), full suite clean, `just it-util realpath` 61/61, `just it` all 48 utilities green after merging main.
- Manual matrix vs GNU 9.7: all empty/relative base and `-e` cases match exactly (including `--relative-to=. /tmp`).

## Adversarial review
Approved after two rounds. Documented divergences (project-consistent, non-blocking): diagnostics print the unquoted path (`realpath: : No such...` vs GNU's `''`); `-q` suppresses base errors uniformly (GNU exempts them). One tracked follow-up appended to #51: `canonicalizeMissing`/`resolveLogical` have an empty-as-cwd special case that must become ENOENT when #51 lands, or `-s`/`-m` empty-base will silently diverge from GNU.

Closes #46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fqscf2s7jmDAEEybsRH6qt

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized realpath path-resolution change with broad regression tests; no auth, security, or cross-utility behavior changes beyond fixing crashes and matching GNU for edge inputs.
> 
> **Overview**
> Fixes **realpath** aborting (SIGABRT / exit 134) when empty or relative paths reached `realPathFileAbsolute`’s `isAbsolute` assert—e.g. empty or relative `--relative-to=` / `--relative-base=`, empty `-e` operands, or relative `-e` paths.
> 
> The shared helper is renamed to **`realPathDupe`**: empty inputs return **ENOENT** (exit 1, GNU-style message) instead of hitting the assert, and both relative and absolute paths go through **`cwd().realPathFile`** so bases like `.` resolve against the working directory. **`-e`** and the default symlink-following relative-base path use this helper.
> 
> **CHANGELOG** documents the fix; new unit and shell integration tests lock in the no-panic behavior and GNU-aligned outcomes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d263ec5c50616b4758d5e5b393721b210274c25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->