### PR TITLE
realpath/readlink: fix relative paths under Threaded io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 ## Unreleased
 
 ### Fixed
+- **realpath/readlink resolve relative paths again with `-s` and
+  `-m`.** A Zig 0.16 Threaded-io regression made `cwd().realPath`
+  fail on the AT_FDCWD pseudo-fd, so `realpath -s <relative>`,
+  `realpath -m <relative>`, and `readlink -m <relative>` reported
+  "No such file or directory" for paths that exist. Empty
+  operands now also error with exit 1 under `-s`/`-m`, matching
+  GNU, instead of resolving to the working directory.
 - **The directory walker follows symlinks correctly under
   `follow_all`, fixing `chown -RL` and `du -L` on symlinked
   files.** Every symlink was classified as a directory without

--- a/src/common/lib.zig
+++ b/src/common/lib.zig
@@ -658,4 +658,8 @@ test {
     _ = @import("git.zig");
     _ = @import("walker.zig");
     _ = @import("prompt.zig");
+    // path.zig tests were dormant (never force-imported here), so its coverage
+    // (canonicalizeMissing / canonicalizeParentMustExist) never ran. Include it
+    // so the issue #51 canonicalizeMissing regression tests actually execute.
+    _ = @import("path.zig");
 }

--- a/src/common/path.zig
+++ b/src/common/path.zig
@@ -88,11 +88,12 @@ pub fn canonicalizeParentMustExist(allocator: Allocator, io: std.Io, path: []con
 /// parts with `.` and `..` cleaned logically.
 pub fn canonicalizeMissing(allocator: Allocator, io: std.Io, path: []const u8) ![]u8 {
     if (path.len == 0) {
-        // Empty path: return current directory
-        var buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
-        const len = try std.Io.Dir.cwd().realPath(io, &buf);
-        return try allocator.dupe(u8, buf[0..len]);
+        // GNU realpath -m / readlink -m report "No such file or directory" for
+        // an empty operand rather than resolving it to the cwd (issue #51
+        // addendum, matching canonicalizeParentMustExist and realPathDupe).
+        return error.FileNotFound;
     }
+    std.debug.assert(path.len > 0);
 
     const abs_path = try canonicalizeMissing_absolutePath(allocator, io, path);
     defer allocator.free(abs_path);
@@ -148,8 +149,12 @@ fn canonicalizeMissing_absolutePath(
     const result = if (std.fs.path.isAbsolute(path))
         try allocator.dupe(u8, path)
     else blk: {
+        // cwd().realPathFile(".", ...) resolves the cwd via a real dir handle.
+        // Avoid cwd().realPath (issue #51: broken under Threaded io; it
+        // readlinks the AT_FDCWD pseudo-fd and fails with ENOENT).
         var cwd_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
-        const cwd_len = try std.Io.Dir.cwd().realPath(io, &cwd_buf);
+        const cwd_len = try std.Io.Dir.cwd().realPathFile(io, ".", &cwd_buf);
+        std.debug.assert(cwd_len > 0);
         std.debug.assert(cwd_len <= cwd_buf.len);
         const cwd = cwd_buf[0..cwd_len];
         break :blk try std.fmt.allocPrint(allocator, "{s}/{s}", .{ cwd, path });

--- a/src/common/path.zig
+++ b/src/common/path.zig
@@ -351,11 +351,49 @@ test "canonicalizeMissing: dotdot past root returns root" {
     try testing.expectEqualStrings("/", result);
 }
 
-test "canonicalizeMissing: empty path returns cwd" {
-    const result = try canonicalizeMissing(testing.allocator, testing.io, "");
+test "canonicalizeMissing: empty path returns FileNotFound (issue #51)" {
+    // GNU realpath -m '' reports "No such file or directory"; it does not treat
+    // an empty operand as the cwd. canonicalizeMissing must reject a zero-length
+    // path with FileNotFound to match (issue #51 addendum). This replaces the
+    // old "empty path returns cwd" assertion, which contradicted GNU parity and
+    // was only ever masked by the AT_FDCWD cwd().realPath breakage.
+    const result = canonicalizeMissing(testing.allocator, testing.io, "");
+    try testing.expectError(error.FileNotFound, result);
+}
+
+// A relative path with a missing tail must resolve against the cwd. Before the
+// #51 fix canonicalizeMissing_absolutePath calls cwd().realPath, which is broken
+// under 0.16 Threaded io (readlinks the AT_FDCWD pseudo-fd) and fails with
+// ENOENT. We chdir into a tmp dir so "." is deterministic; the original cwd is
+// restored via setCurrentDir on exit. Pins the shared helper independently of
+// its realpath/readlink callers.
+test "canonicalizeMissing: relative path resolves against cwd (issue #51)" {
+    const io = testing.io;
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    var saved_cwd_dir = try std.Io.Dir.cwd().openDir(io, ".", .{});
+    defer {
+        std.process.setCurrentDir(io, saved_cwd_dir) catch {};
+        saved_cwd_dir.close(io);
+    }
+
+    const tmp_abs = try tmp_dir.dir.realPathFileAlloc(io, ".", testing.allocator);
+    defer testing.allocator.free(tmp_abs);
+
+    try std.Io.Threaded.chdir(tmp_abs);
+
+    const expected = try std.fmt.allocPrint(
+        testing.allocator,
+        "{s}/relmissing/tail",
+        .{tmp_abs},
+    );
+    defer testing.allocator.free(expected);
+
+    const result = try canonicalizeMissing(testing.allocator, io, "relmissing/tail");
     defer testing.allocator.free(result);
-    try testing.expect(result.len > 0);
-    try testing.expectEqual(@as(u8, '/'), result[0]);
+
+    try testing.expectEqualStrings(expected, result);
 }
 
 test "canonicalizeMissing: root only returns root" {
@@ -452,7 +490,7 @@ test "canonicalizeParentMustExist: file as parent fails with NotDir" {
     const io = testing.io;
     const f = try tmp.dir.createFile(io, "real_file", .{});
     try f.writeStreamingAll(io, "x");
-    try f.close(io);
+    f.close(io);
     var path_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
     const dir_len = try tmp.dir.realPath(io, &path_buf);
     const dir_path = path_buf[0..dir_len];

--- a/src/readlink.zig
+++ b/src/readlink.zig
@@ -603,6 +603,47 @@ test "readlink canonicalize-missing (-m) with nonexistent path" {
     try testing.expect(std.mem.endsWith(u8, out, "nonexistent/file.txt\n"));
 }
 
+// readlink -m shares canonicalizeMissing with realpath -m, so it inherits the
+// #51 relative-path breakage: cwd().realPath (broken under 0.16 Threaded io,
+// readlinks the AT_FDCWD pseudo-fd) fails with ENOENT for a relative operand.
+// GNU resolves it against the cwd. We chdir into a tmp dir so "." is
+// deterministic; the original cwd is restored via setCurrentDir on exit. This
+// is the "other caller of canonicalizeMissing" the issue calls out.
+test "readlink -m relative path with missing tail resolves via cwd (issue #51)" {
+    const io = testing.io;
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    var saved_cwd_dir = try std.Io.Dir.cwd().openDir(io, ".", .{});
+    defer {
+        std.process.setCurrentDir(io, saved_cwd_dir) catch {};
+        saved_cwd_dir.close(io);
+    }
+
+    const tmp_abs = try tmp_dir.dir.realPathFileAlloc(io, ".", testing.allocator);
+    defer testing.allocator.free(tmp_abs);
+
+    try std.Io.Threaded.chdir(tmp_abs);
+
+    const expected = try std.fmt.allocPrint(testing.allocator, "{s}/nosuch/child\n", .{tmp_abs});
+    defer testing.allocator.free(expected);
+
+    var stdout_aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer stdout_aw.deinit();
+
+    const args = [_][]const u8{ "-m", "nosuch/child" };
+    const result = try runReadlink(
+        testing.allocator,
+        io,
+        &args,
+        &stdout_aw.writer,
+        common.null_writer,
+    );
+
+    try testing.expectEqual(@as(u8, 0), result);
+    try testing.expectEqualStrings(expected, stdout_aw.writer.buffered());
+}
+
 test "readlink no-newline (-n)" {
     const io = testing.io;
     var tmp_dir = testing.tmpDir(.{});

--- a/src/realpath.zig
+++ b/src/realpath.zig
@@ -1278,6 +1278,287 @@ test "realpath: -e resolves a relative existing file to an absolute path (issue 
 }
 
 // ============================================================================
+// Issue #51: -s / -m with relative paths must resolve against the cwd.
+// cwd().realPath is broken under 0.16 Threaded io (it readlinks the AT_FDCWD
+// pseudo-fd /proc/self/fd/-100), so resolveLogical (-s) and canonicalizeMissing
+// (-m) fail with ENOENT for existing relative paths where GNU succeeds. We chdir
+// into a tmp dir so "." is deterministic and independent of the repo cwd; the
+// original cwd handle is restored via setCurrentDir on exit.
+// ============================================================================
+
+// -s on a relative existing path must resolve to its absolute form via the cwd.
+// Before the fix resolveLogical's relative branch calls cwd().realPath and
+// aborts with ENOENT; GNU prints the absolute path and exits 0.
+test "realpath: -s relative existing path resolves via cwd (issue #51)" {
+    const io = testing.io;
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    {
+        const file = try tmp_dir.dir.createFile(io, "motd", .{});
+        file.close(io);
+    }
+
+    var saved_cwd_dir = try std.Io.Dir.cwd().openDir(io, ".", .{});
+    defer {
+        std.process.setCurrentDir(io, saved_cwd_dir) catch {};
+        saved_cwd_dir.close(io);
+    }
+
+    const tmp_abs = try tmp_dir.dir.realPathFileAlloc(io, ".", testing.allocator);
+    defer testing.allocator.free(tmp_abs);
+
+    try std.Io.Threaded.chdir(tmp_abs);
+
+    const expected = try std.fmt.allocPrint(testing.allocator, "{s}/motd\n", .{tmp_abs});
+    defer testing.allocator.free(expected);
+
+    var stdout_aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer stdout_aw.deinit();
+    var stderr_aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer stderr_aw.deinit();
+
+    const args = [_][]const u8{ "-s", "./motd" };
+    const result = try runRealpath(
+        testing.allocator,
+        io,
+        &args,
+        &stdout_aw.writer,
+        &stderr_aw.writer,
+    );
+
+    try testing.expectEqual(@as(u8, 0), result);
+    try testing.expectEqualStrings(expected, stdout_aw.writer.buffered());
+}
+
+// -s on a relative path carrying "." and ".." exercises resolveLogical's
+// relative-branch cleanup, not just a bare relative name. ./sub/./../sub must
+// clean to <cwd>/sub.
+test "realpath: -s relative path with dot components resolves via cwd (issue #51)" {
+    const io = testing.io;
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    try tmp_dir.dir.createDirPath(io, "sub");
+
+    var saved_cwd_dir = try std.Io.Dir.cwd().openDir(io, ".", .{});
+    defer {
+        std.process.setCurrentDir(io, saved_cwd_dir) catch {};
+        saved_cwd_dir.close(io);
+    }
+
+    const tmp_abs = try tmp_dir.dir.realPathFileAlloc(io, ".", testing.allocator);
+    defer testing.allocator.free(tmp_abs);
+
+    try std.Io.Threaded.chdir(tmp_abs);
+
+    const expected = try std.fmt.allocPrint(testing.allocator, "{s}/sub\n", .{tmp_abs});
+    defer testing.allocator.free(expected);
+
+    var stdout_aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer stdout_aw.deinit();
+    var stderr_aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer stderr_aw.deinit();
+
+    const args = [_][]const u8{ "-s", "./sub/./../sub" };
+    const result = try runRealpath(
+        testing.allocator,
+        io,
+        &args,
+        &stdout_aw.writer,
+        &stderr_aw.writer,
+    );
+
+    try testing.expectEqual(@as(u8, 0), result);
+    try testing.expectEqualStrings(expected, stdout_aw.writer.buffered());
+}
+
+// -m on a relative path with a missing tail must resolve the whole thing
+// against the cwd. Before the fix canonicalizeMissing_absolutePath calls
+// cwd().realPath and aborts with ENOENT; GNU prints <cwd>/nosuch/dir, exit 0.
+test "realpath: -m relative path with missing tail resolves via cwd (issue #51)" {
+    const io = testing.io;
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    var saved_cwd_dir = try std.Io.Dir.cwd().openDir(io, ".", .{});
+    defer {
+        std.process.setCurrentDir(io, saved_cwd_dir) catch {};
+        saved_cwd_dir.close(io);
+    }
+
+    const tmp_abs = try tmp_dir.dir.realPathFileAlloc(io, ".", testing.allocator);
+    defer testing.allocator.free(tmp_abs);
+
+    try std.Io.Threaded.chdir(tmp_abs);
+
+    const expected = try std.fmt.allocPrint(testing.allocator, "{s}/nosuch/dir\n", .{tmp_abs});
+    defer testing.allocator.free(expected);
+
+    var stdout_aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer stdout_aw.deinit();
+    var stderr_aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer stderr_aw.deinit();
+
+    const args = [_][]const u8{ "-m", "nosuch/dir" };
+    const result = try runRealpath(
+        testing.allocator,
+        io,
+        &args,
+        &stdout_aw.writer,
+        &stderr_aw.writer,
+    );
+
+    try testing.expectEqual(@as(u8, 0), result);
+    try testing.expectEqualStrings(expected, stdout_aw.writer.buffered());
+}
+
+// -m on a relative path whose components all exist must resolve to the
+// canonical absolute path via the cwd.
+test "realpath: -m relative path with existing components resolves via cwd (issue #51)" {
+    const io = testing.io;
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    try tmp_dir.dir.createDirPath(io, "sub");
+
+    var saved_cwd_dir = try std.Io.Dir.cwd().openDir(io, ".", .{});
+    defer {
+        std.process.setCurrentDir(io, saved_cwd_dir) catch {};
+        saved_cwd_dir.close(io);
+    }
+
+    const tmp_abs = try tmp_dir.dir.realPathFileAlloc(io, ".", testing.allocator);
+    defer testing.allocator.free(tmp_abs);
+
+    try std.Io.Threaded.chdir(tmp_abs);
+
+    const expected = try std.fmt.allocPrint(testing.allocator, "{s}/sub\n", .{tmp_abs});
+    defer testing.allocator.free(expected);
+
+    var stdout_aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer stdout_aw.deinit();
+    var stderr_aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer stderr_aw.deinit();
+
+    const args = [_][]const u8{ "-m", "sub" };
+    const result = try runRealpath(
+        testing.allocator,
+        io,
+        &args,
+        &stdout_aw.writer,
+        &stderr_aw.writer,
+    );
+
+    try testing.expectEqual(@as(u8, 0), result);
+    try testing.expectEqualStrings(expected, stdout_aw.writer.buffered());
+}
+
+// ----------------------------------------------------------------------------
+// Issue #51 addendum: once cwd().realPath works, the empty-as-cwd special cases
+// masked by the breakage must still reject a zero-length operand with ENOENT to
+// match GNU (`realpath -s ''` / `-m ''` -> "No such file or directory", exit 1),
+// rather than silently resolving to the cwd. These guard against a naive fix
+// that drops the empty-path guards; they must stay green before AND after.
+// ----------------------------------------------------------------------------
+
+test "realpath: -s empty operand errors, not resolves to cwd (issue #51)" {
+    const io = testing.io;
+    var stdout_aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer stdout_aw.deinit();
+    var stderr_aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer stderr_aw.deinit();
+
+    const args = [_][]const u8{ "-s", "" };
+    const result = try runRealpath(
+        testing.allocator,
+        io,
+        &args,
+        &stdout_aw.writer,
+        &stderr_aw.writer,
+    );
+
+    try testing.expectEqual(@as(u8, 1), result);
+    try testing.expectEqual(@as(usize, 0), stdout_aw.writer.buffered().len);
+    try testing.expect(
+        std.mem.find(u8, stderr_aw.writer.buffered(), "No such file or directory") != null,
+    );
+}
+
+test "realpath: -m empty operand errors, not resolves to cwd (issue #51)" {
+    const io = testing.io;
+    var stdout_aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer stdout_aw.deinit();
+    var stderr_aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer stderr_aw.deinit();
+
+    const args = [_][]const u8{ "-m", "" };
+    const result = try runRealpath(
+        testing.allocator,
+        io,
+        &args,
+        &stdout_aw.writer,
+        &stderr_aw.writer,
+    );
+
+    try testing.expectEqual(@as(u8, 1), result);
+    try testing.expectEqual(@as(usize, 0), stdout_aw.writer.buffered().len);
+    try testing.expect(
+        std.mem.find(u8, stderr_aw.writer.buffered(), "No such file or directory") != null,
+    );
+}
+
+// -s with an empty --relative-to= routes the empty base through resolveLogical
+// (processPath_resolveBase's no_symlinks branch); it must error, not resolve
+// the base to the cwd.
+test "realpath: -s empty --relative-to= errors (issue #51)" {
+    const io = testing.io;
+    var stdout_aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer stdout_aw.deinit();
+    var stderr_aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer stderr_aw.deinit();
+
+    const args = [_][]const u8{ "-s", "--relative-to=", "/tmp" };
+    const result = try runRealpath(
+        testing.allocator,
+        io,
+        &args,
+        &stdout_aw.writer,
+        &stderr_aw.writer,
+    );
+
+    try testing.expectEqual(@as(u8, 1), result);
+    try testing.expect(
+        std.mem.find(u8, stderr_aw.writer.buffered(), "No such file or directory") != null,
+    );
+}
+
+// -m with an empty --relative-base= routes the empty base through
+// canonicalizeMissing (processPath_resolveBase's canonicalize_missing branch);
+// it must error, not resolve the base to the cwd.
+test "realpath: -m empty --relative-base= errors (issue #51)" {
+    const io = testing.io;
+    var stdout_aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer stdout_aw.deinit();
+    var stderr_aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer stderr_aw.deinit();
+
+    const args = [_][]const u8{ "-m", "--relative-base=", "/tmp" };
+    const result = try runRealpath(
+        testing.allocator,
+        io,
+        &args,
+        &stdout_aw.writer,
+        &stderr_aw.writer,
+    );
+
+    try testing.expectEqual(@as(u8, 1), result);
+    try testing.expect(
+        std.mem.find(u8, stderr_aw.writer.buffered(), "No such file or directory") != null,
+    );
+}
+
+// ============================================================================
 // E7: Behavioral tests — all-but-last-exist semantics (GNU default mode)
 // ============================================================================
 

--- a/src/realpath.zig
+++ b/src/realpath.zig
@@ -78,12 +78,24 @@ const RealpathArgs = struct {
 /// Resolve a path without following symlinks, just cleaning . and .. components.
 /// Makes the path absolute and removes redundant separators and dot components.
 fn resolveLogical(allocator: Allocator, io: std.Io, path: []const u8) ![]u8 {
+    // GNU realpath -s reports "No such file or directory" for an empty operand
+    // rather than resolving it to the cwd. Reject it here so an empty
+    // --relative-to= base routed through this path errors like GNU.
+    if (path.len == 0) {
+        return error.FileNotFound;
+    }
+    std.debug.assert(path.len > 0);
+
     // Get absolute path by prepending cwd if relative
     const abs_path = if (std.fs.path.isAbsolute(path))
         try allocator.dupe(u8, path)
     else blk: {
+        // cwd().realPathFile(".", ...) resolves the cwd via a real dir handle.
+        // Avoid cwd().realPath (issue #51: broken under Threaded io; it
+        // readlinks the AT_FDCWD pseudo-fd and fails with ENOENT).
         var cwd_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
-        const cwd_len = std.Io.Dir.cwd().realPath(io, &cwd_buf) catch return error.FileNotFound;
+        const cwd_len = std.Io.Dir.cwd().realPathFile(io, ".", &cwd_buf) catch
+            return error.FileNotFound;
         break :blk try std.fs.path.join(allocator, &.{ cwd_buf[0..cwd_len], path });
     };
     defer allocator.free(abs_path);


### PR DESCRIPTION
## Summary
`realpath -s <relative>` and `realpath -m <relative>` (and `readlink -m <relative>`) failed with ENOENT for paths that exist; GNU succeeds. Root cause: `std.Io.Dir.cwd().realPath()` is broken under 0.16 Threaded io — it readlinks `/proc/self/fd/-100` (AT_FDCWD is not a real fd; symmetric on macOS/Linux). The cwd now resolves through `cwd().realPathFile(io, ".", buf)` (a real handle) in `resolveLogical` and `canonicalizeMissing_absolutePath` — the exact three broken call sites, audited as the only ones in src/.

Per the #46-review addendum, empty operands now report `No such file or directory` with exit 1 in the same sites (GNU parity) instead of silently resolving to the cwd once the breakage was fixed.

Bonus hardening: `src/common/path.zig`'s test block was never compiled into the suite; it's now force-imported (+19 tests, suite total 2238) with one latent 0.16 bit-rot compile error fixed.

## TDD evidence
- RED (8dfaa5e): 6 tests fail with the exact AT_FDCWD ENOENT (reviewer independently reproduced from a staged-only reconstruction, right-reason stack traces through `Dir.realPath`).
- GREEN (a857b90): full suite 2238 tests clean; `just it-util realpath` 61/61; `just it-util readlink` 38/38; `just it` all 48 utilities after merging main.
- GNU 9.7 matrix (~40 cases): all match, including the reviewer's attempted refutation of $PWD semantics (GNU prints physical paths; so do we).

## Adversarial review
Approved. Addendum guards proven able to fail via scratch-tree sabotage. Non-blocking follow-ups recorded: `-s` does purely textual `..` popping where GNU requires the preceding component to exist (pre-existing, same for absolute paths on main); operand quoting in error messages (project-wide convention).

Closes #51.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fqscf2s7jmDAEEybsRH6qt

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core path canonicalization for realpath/readlink with broad new tests; behavior change is GNU-aligned but any missed `cwd().realPath` caller could still mis-resolve paths.
> 
> **Overview**
> Fixes **realpath** `-s`/`-m`, **readlink** `-m`, and shared **`canonicalizeMissing`** so relative operands resolve against the cwd again under Zig 0.16 Threaded io. The broken path was **`cwd().realPath`**, which readlinks the AT_FDCWD pseudo-fd and returned ENOENT; those sites now use **`cwd().realPathFile(io, ".", buf)`** instead.
> 
> **Empty operands** under `-s`/`-m` (and empty `--relative-to=` / `--relative-base=` bases) now fail with GNU-style *No such file or directory* and exit 1 via **`FileNotFound`**, instead of treating `""` as the working directory once cwd resolution worked.
> 
> **Test suite:** `path.zig` is force-imported from `common/lib.zig` so its regression tests actually run; large issue #51 coverage was added in `realpath`, `readlink`, and `path.zig`. CHANGELOG documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f578934326d2d1a34ef3845e9c83d1f297e3ffb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->