### PR TITLE
dd: count/skip/seek suffixes, conv=fdatasync, sync hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,20 @@
 
 ## Unreleased
 
+### Added
+- **dd `count=`/`skip=`/`seek=` accept size suffixes and
+  `conv=fdatasync` is supported.** The count-like operands now
+  honor the same K/M/G suffix grammar as `bs=` (as block-count
+  multipliers, matching GNU), and `conv=fdatasync` performs a
+  data-only flush before exit (full fsync on non-Linux and when
+  combined with `conv=fsync`).
+
 ### Fixed
+- **dd `conv=fdatasync`/`conv=fsync` report sync failures
+  instead of aborting.** Syncing a pipe (for example dd in a
+  pipeline) previously crashed with SIGABRT; it now reports
+  `fsync failed for 'standard output'` and exits 1, matching
+  GNU.
 - **realpath/readlink resolve relative paths again with `-s` and
   `-m`.** A Zig 0.16 Threaded-io regression made `cwd().realPath`
   fail on the AT_FDCWD pseudo-fd, so `realpath -s <relative>`,

--- a/docs/specs/dd-flags.md
+++ b/docs/specs/dd-flags.md
@@ -50,7 +50,7 @@ Operands are treated as flags for this table.
 | parset |     | yes   |         |     | yes  | SHOULD |
 | excl  |      |       |         | yes |      | WONT |
 | nocreat |    |       |         | yes |      | WONT |
-| fdatasync |  |       |         | yes |      | WONT |
+| fdatasync |  |       |         | yes | yes  | SHOULD |
 
 ### status= values
 

--- a/man/man1/dd.1
+++ b/man/man1/dd.1
@@ -101,6 +101,26 @@ would retry such a region without bound, bound it explicitly with
 Pad each input block with NUL bytes to
 .Cm ibs
 size.
+.It Cm fsync
+Synchronize output data and metadata to disk before closing.
+.It Cm fdatasync
+Synchronize output data to disk before closing.
+Unlike
+.Cm fsync ,
+file metadata need not be flushed.
+On platforms other than Linux a full
+.Cm fsync
+is performed instead.
+When both
+.Cm fsync
+and
+.Cm fdatasync
+are given, a single full
+.Cm fsync
+is performed.
+If the output cannot be synchronized (for example, it is a pipe),
+.Nm
+reports the failure and exits with a nonzero status.
 .El
 .It Cm status Ns = Ns Ar level
 Control the information printed to standard error:
@@ -126,6 +146,19 @@ Sizes may also use
 .Ql x
 for multiplication (e.g.,
 .Dq 1024x1024 ) .
+The block-count operands
+.Cm count ,
+.Cm skip ,
+and
+.Cm seek
+(and the aliases
+.Cm iseek
+and
+.Cm oseek )
+accept the same suffixes, where the suffix multiplies the block count
+(e.g.,
+.Cm count Ns = Ns Cm 1k
+copies 1024 blocks).
 .Sh EXIT STATUS
 .Ex -std dd
 .Sh EXAMPLES

--- a/src/dd.zig
+++ b/src/dd.zig
@@ -190,26 +190,25 @@ fn parseOperands_applyKeyValue(config: *DdConfig, key: []const u8, value: []cons
     } else if (std.mem.eql(u8, key, "obs")) {
         config.obs = try parseByteSize(value);
     } else if (std.mem.eql(u8, key, "count")) {
-        config.count = std.fmt.parseInt(usize, value, 10) catch // tiger:allow:usize-arch byte-count
-            return error.InvalidValue;
+        // Issue #43: count/skip/seek take the same multiplicative suffix
+        // grammar as bs=. Here the suffix is a pure block-count multiplier
+        // (count=1k means 1024 blocks), so parseByteSize's number is used
+        // verbatim without any byte conversion.
+        config.count = try parseByteSize(value);
     } else if (std.mem.eql(u8, key, "skip")) {
-        config.skip = std.fmt.parseInt(usize, value, 10) catch // tiger:allow:usize-arch byte-count
-            return error.InvalidValue;
+        config.skip = try parseByteSize(value);
     } else if (std.mem.eql(u8, key, "seek")) {
-        config.seek = std.fmt.parseInt(usize, value, 10) catch // tiger:allow:usize-arch byte-count
-            return error.InvalidValue;
+        config.seek = try parseByteSize(value);
     } else if (std.mem.eql(u8, key, "cbs")) {
         config.cbs = try parseByteSize(value);
     } else if (std.mem.eql(u8, key, "conv")) {
         try parseConversions(config, value);
     } else if (std.mem.eql(u8, key, "iseek")) {
-        // Alias for skip
-        config.skip = std.fmt.parseInt(usize, value, 10) catch // tiger:allow:usize-arch byte-count
-            return error.InvalidValue;
+        // Alias for skip; same suffix grammar as skip=.
+        config.skip = try parseByteSize(value);
     } else if (std.mem.eql(u8, key, "oseek")) {
-        // Alias for seek
-        config.seek = std.fmt.parseInt(usize, value, 10) catch // tiger:allow:usize-arch byte-count
-            return error.InvalidValue;
+        // Alias for seek; same suffix grammar as seek=.
+        config.seek = try parseByteSize(value);
     } else if (std.mem.eql(u8, key, "fillchar")) {
         if (value.len != 1) return error.InvalidValue;
         config.fillchar = value[0];
@@ -260,6 +259,8 @@ fn parseConversions(config: *DdConfig, value: []const u8) !void {
             config.conv_sync = true;
         } else if (std.mem.eql(u8, conv, "fsync")) {
             config.conv_fsync = true;
+        } else if (std.mem.eql(u8, conv, "fdatasync")) {
+            config.conv_fdatasync = true;
         } else if (std.mem.eql(u8, conv, "osync")) {
             config.conv_osync = true;
         } else if (std.mem.eql(u8, conv, "swab")) {
@@ -495,6 +496,7 @@ fn printHelp(allocator: Allocator, writer: anytype) !void {
         \\  noerror   continue after read errors
         \\  sync      pad input blocks with NULs to ibs size
         \\  fsync     fsync output file before closing
+        \\  fdatasync fdatasync output data before closing
         \\  osync     pad final output block with NULs to obs size
         \\
         \\Examples:
@@ -1558,24 +1560,91 @@ fn runDd_finish(
         if (code != @intFromEnum(common.ExitCode.success)) return code;
     }
 
-    // fsync the output file if requested
-    if (config.conv_fsync) {
-        ctx.output_file.sync(ctx.io) catch |err| {
-            const message = common.posixErrorString(err);
-            common.printErrorWithProgram(
-                ctx.allocator,
-                ctx.stderr,
-                "dd",
-                "fsync error: {s}",
-                .{message},
-            );
-            return @intFromEnum(common.ExitCode.general_error);
-        };
-    }
+    // Sync the output file if conv=fsync or conv=fdatasync was requested.
+    const sync_code = runDd_finish_sync(ctx, config);
+    if (sync_code != @intFromEnum(common.ExitCode.success)) return sync_code;
 
     // Print statistics
     printStats(ctx.io, ctx.stderr, ctx.stats.*, config.status);
     return @intFromEnum(common.ExitCode.success);
+}
+
+/// Flush the output file to disk for conv=fsync and/or conv=fdatasync.
+/// conv=fdatasync flushes data only via fdatasync(2); conv=fsync flushes
+/// data and metadata. A full fsync subsumes a data-only sync, so when both
+/// are requested a single fsync suffices (matching GNU dd). fdatasync is
+/// Linux-only; on other platforms a full fsync is performed instead.
+///
+/// We issue the raw syscalls and inspect errno directly rather than call
+/// std.posix.fdatasync / File.sync: those mark EINVAL "unreachable" and so
+/// panic (SIGABRT) when the output is a pipe or other object that cannot be
+/// synced. Like gnulib's fdatasync replacement, EINVAL/ENOSYS from
+/// fdatasync fall back to a full fsync; a genuine fsync failure (e.g. the
+/// output is a pipe) is reported GNU-style and exits nonzero.
+fn runDd_finish_sync(ctx: *const DdWriteCtx, config: *const DdConfig) u8 {
+    const want_full = config.conv_fsync;
+    const want_data = config.conv_fdatasync;
+    if (!want_full and !want_data) return @intFromEnum(common.ExitCode.success);
+
+    const fd = ctx.output_file.handle;
+    const target = config.output_file orelse "standard output";
+    const use_fdatasync = want_data and !want_full and builtin.os.tag == .linux;
+    if (use_fdatasync) {
+        // A data-only sync is chosen only when no full fsync was requested.
+        std.debug.assert(!want_full);
+        // The fdatasync(2) path is reachable on Linux alone.
+        std.debug.assert(builtin.os.tag == .linux);
+        switch (std.posix.errno(std.posix.system.fdatasync(fd))) {
+            .SUCCESS => return @intFromEnum(common.ExitCode.success),
+            // No fdatasync for this fd/filesystem: fall through to fsync.
+            .INVAL, .NOSYS => {},
+            else => |err| return runDd_finish_sync_fail(ctx, "fdatasync", target, err),
+        }
+    }
+
+    // Full fsync: conv=fsync, the fdatasync fallback, or non-Linux fdatasync.
+    switch (std.posix.errno(std.posix.system.fsync(fd))) {
+        .SUCCESS => return @intFromEnum(common.ExitCode.success),
+        else => |err| return runDd_finish_sync_fail(ctx, "fsync", target, err),
+    }
+}
+
+/// Report a failed output sync GNU-style ("dd: fsync failed for
+/// 'standard output': Invalid argument") and map it to dd's fatal exit
+/// code. `op` names the syscall and `target` names the output operand.
+fn runDd_finish_sync_fail(
+    ctx: *const DdWriteCtx,
+    op: []const u8,
+    target: []const u8,
+    err: std.posix.E,
+) u8 {
+    std.debug.assert(op.len > 0);
+    std.debug.assert(err != .SUCCESS);
+
+    const detail = runDd_finish_sync_errnoString(err);
+    common.printErrorWithProgram(
+        ctx.allocator,
+        ctx.stderr,
+        "dd",
+        "{s} failed for '{s}': {s}",
+        .{ op, target, detail },
+    );
+    return @intFromEnum(common.ExitCode.general_error);
+}
+
+/// Human-readable text for the errno values an output sync can report, so
+/// dd's diagnostics read like GNU's rather than exposing raw errno tags.
+fn runDd_finish_sync_errnoString(err: std.posix.E) []const u8 {
+    std.debug.assert(err != .SUCCESS);
+    return switch (err) {
+        .INVAL => "Invalid argument",
+        .BADF => "Bad file descriptor",
+        .IO => "Input/output error",
+        .NOSPC => "No space left on device",
+        .DQUOT => "Disk quota exceeded",
+        .ROFS => "Read-only file system",
+        else => @tagName(err),
+    };
 }
 
 /// Process files or stdin with dd operands

--- a/src/dd.zig
+++ b/src/dd.zig
@@ -57,6 +57,7 @@ const DdConfig = struct {
     conv_noerror: bool = false,
     conv_sync: bool = false,
     conv_fsync: bool = false,
+    conv_fdatasync: bool = false,
     conv_osync: bool = false,
     conv_swab: bool = false,
     conv_ascii: bool = false,
@@ -1643,6 +1644,83 @@ test "parseOperands - count skip seek" {
     try testing.expectEqual(@as(usize, 3), config.seek);
 }
 
+// Issue #43: count=/skip=/seek= must accept the same K/M/G/b suffix
+// grammar that bs= already honors. GNU applies the multiplicative
+// suffix table to both N (count/skip/seek) and BYTES (bs) operands.
+test "parseOperands - count suffix k" {
+    const args = [_][]const u8{"count=1k"};
+    const config = try parseOperands(&args);
+    try testing.expectEqual(@as(?usize, 1024), config.count);
+    // Sibling operands must remain at their defaults.
+    try testing.expectEqual(@as(usize, 0), config.skip);
+}
+
+test "parseOperands - count suffix M" {
+    const args = [_][]const u8{"count=2M"};
+    const config = try parseOperands(&args);
+    try testing.expectEqual(@as(?usize, 2 * 1048576), config.count);
+    try testing.expectEqual(@as(usize, 0), config.seek);
+}
+
+test "parseOperands - count suffix b block" {
+    const args = [_][]const u8{"count=1b"};
+    const config = try parseOperands(&args);
+    try testing.expectEqual(@as(?usize, 512), config.count);
+    try testing.expectEqual(@as(usize, 0), config.skip);
+}
+
+test "parseOperands - skip suffix k" {
+    const args = [_][]const u8{"skip=1k"};
+    const config = try parseOperands(&args);
+    try testing.expectEqual(@as(usize, 1024), config.skip);
+    try testing.expectEqual(@as(usize, 0), config.seek);
+}
+
+test "parseOperands - seek suffix k" {
+    const args = [_][]const u8{"seek=1k"};
+    const config = try parseOperands(&args);
+    try testing.expectEqual(@as(usize, 1024), config.seek);
+    try testing.expectEqual(@as(usize, 0), config.skip);
+}
+
+test "parseOperands - iseek suffix maps to skip" {
+    const args = [_][]const u8{"iseek=1k"};
+    const config = try parseOperands(&args);
+    try testing.expectEqual(@as(usize, 1024), config.skip);
+    try testing.expectEqual(@as(usize, 0), config.seek);
+}
+
+test "parseOperands - oseek suffix maps to seek" {
+    const args = [_][]const u8{"oseek=1k"};
+    const config = try parseOperands(&args);
+    try testing.expectEqual(@as(usize, 1024), config.seek);
+    try testing.expectEqual(@as(usize, 0), config.skip);
+}
+
+// Regression guard: plain integer counts must parse identically after
+// routing through parseByteSize. Must be GREEN before and after the fix.
+test "parseOperands - plain integer count skip seek unchanged" {
+    const args = [_][]const u8{ "count=2", "skip=3", "seek=4" };
+    const config = try parseOperands(&args);
+    try testing.expectEqual(@as(?usize, 2), config.count);
+    try testing.expectEqual(@as(usize, 3), config.skip);
+    try testing.expectEqual(@as(usize, 4), config.seek);
+}
+
+test "parseOperands - count zero stays zero" {
+    const args = [_][]const u8{"count=0"};
+    const config = try parseOperands(&args);
+    try testing.expectEqual(@as(?usize, 0), config.count);
+    try testing.expectEqual(@as(usize, 0), config.skip);
+}
+
+// Lowercase 'm' is not in the bs= suffix table; count= must reject it
+// exactly as bs= does. Pins that we did not loosen the grammar.
+test "parseOperands - count lowercase m rejected" {
+    const args = [_][]const u8{"count=1m"};
+    try testing.expectError(error.InvalidValue, parseOperands(&args));
+}
+
 test "parseOperands - conversions" {
     const args = [_][]const u8{"conv=lcase,notrunc,sync"};
     const config = try parseOperands(&args);
@@ -2249,6 +2327,22 @@ test "parseOperands - cbs default is null" {
 test "parseConversions - fsync" {
     const args = [_][]const u8{"conv=fsync"};
     const config = try parseOperands(&args);
+    try testing.expect(config.conv_fsync);
+}
+
+// Issue #43: conv=fdatasync flushes output data before exit, like
+// conv=fsync but data-only. Must parse to its own independent flag.
+test "parseConversions - fdatasync" {
+    const args = [_][]const u8{"conv=fdatasync"};
+    const config = try parseOperands(&args);
+    try testing.expect(config.conv_fdatasync);
+    try testing.expect(!config.conv_fsync);
+}
+
+test "parseConversions - fdatasync and fsync independent" {
+    const args = [_][]const u8{"conv=fdatasync,fsync"};
+    const config = try parseOperands(&args);
+    try testing.expect(config.conv_fdatasync);
     try testing.expect(config.conv_fsync);
 }
 

--- a/tests/utilities/dd_test.sh
+++ b/tests/utilities/dd_test.sh
@@ -187,6 +187,69 @@ test_dd() {
         print_test_result "dd bs=1K suffix" "FAIL" "Expected 1024 bytes, got $file_size"
     fi
 
+    # Issue #43: count= must accept the same suffixes bs= does. This is
+    # the exact command from the issue: bs=512 count=1k -> 512*1024 bytes.
+    local count_suffix_output="$TEMP_DIR/dd_count_suffix.txt"
+    "$binary" if=/dev/zero of="$count_suffix_output" bs=512 count=1k status=none 2>/dev/null
+    local count_suffix_size
+    count_suffix_size=$(get_file_size "$count_suffix_output")
+    if [[ "$count_suffix_size" -eq 524288 ]]; then
+        print_test_result "dd count=1k suffix" "PASS"
+    else
+        print_test_result "dd count=1k suffix" "FAIL" \
+            "Expected 524288 bytes, got $count_suffix_size"
+    fi
+
+    # Issue #43: skip= suffix seeks the input by the suffixed block count.
+    # Build a >1KiB input where byte at offset 1024 is known, copy 1 byte.
+    local skip_suffix_input="$TEMP_DIR/dd_skip_suffix_in.txt"
+    printf '%01024d' 0 > "$skip_suffix_input"
+    printf 'Z' >> "$skip_suffix_input"
+    local skip_suffix_output="$TEMP_DIR/dd_skip_suffix_out.txt"
+    "$binary" if="$skip_suffix_input" of="$skip_suffix_output" \
+        bs=1 skip=1k count=1 status=none 2>/dev/null
+    local skip_suffix_content
+    skip_suffix_content=$(cat "$skip_suffix_output")
+    if [[ "$skip_suffix_content" == "Z" ]]; then
+        print_test_result "dd skip=1k suffix" "PASS"
+    else
+        print_test_result "dd skip=1k suffix" "FAIL" \
+            "Expected 'Z', got '$skip_suffix_content'"
+    fi
+
+    echo -e "${CYAN}Testing conv=fdatasync...${NC}"
+
+    # Issue #43: conv=fdatasync flushes data before exit and copies
+    # normally. Exact second command from the issue.
+    local fdatasync_input=$(create_temp_file "fdatasync payload")
+    local fdatasync_output="$TEMP_DIR/dd_fdatasync.txt"
+    "$binary" if="$fdatasync_input" of="$fdatasync_output" \
+        conv=fdatasync status=none 2>/dev/null
+    local fdatasync_rc=$?
+    local fdatasync_content
+    fdatasync_content=$(cat "$fdatasync_output")
+    if [[ "$fdatasync_rc" -eq 0 && "$fdatasync_content" == "fdatasync payload" ]]; then
+        print_test_result "dd conv=fdatasync" "PASS"
+    else
+        print_test_result "dd conv=fdatasync" "FAIL" \
+            "rc=$fdatasync_rc content='$fdatasync_content'"
+    fi
+
+    # conv=fdatasync,fsync combo: both syncs coexist, data intact.
+    local fdcombo_input=$(create_temp_file "combo payload")
+    local fdcombo_output="$TEMP_DIR/dd_fdcombo.txt"
+    "$binary" if="$fdcombo_input" of="$fdcombo_output" \
+        conv=fdatasync,fsync status=none 2>/dev/null
+    local fdcombo_rc=$?
+    local fdcombo_content
+    fdcombo_content=$(cat "$fdcombo_output")
+    if [[ "$fdcombo_rc" -eq 0 && "$fdcombo_content" == "combo payload" ]]; then
+        print_test_result "dd conv=fdatasync,fsync" "PASS"
+    else
+        print_test_result "dd conv=fdatasync,fsync" "FAIL" \
+            "rc=$fdcombo_rc content='$fdcombo_content'"
+    fi
+
     echo -e "${CYAN}Testing exit codes...${NC}"
 
     # Success exit code

--- a/tests/utilities/dd_test.sh
+++ b/tests/utilities/dd_test.sh
@@ -250,6 +250,34 @@ test_dd() {
             "rc=$fdcombo_rc content='$fdcombo_content'"
     fi
 
+    echo -e "${CYAN}Testing conv=fdatasync on a pipe (issue #43, round 2)...${NC}"
+
+    # Adversarial regression: conv=fdatasync with a pipe as the output must
+    # NEVER abort the process. fdatasync(2) on a pipe returns EINVAL, and
+    # the Zig std marks that errno path unreachable, so the naive
+    # implementation panics (SIGABRT, rc=134). GNU coreutils 9.7 instead
+    # falls back and prints "dd: fsync failed for 'standard output':
+    # Invalid argument" and exits 1 (verified against GNU dd 9.7 on this
+    # host). Contract: rc is 0 or 1 (never >=128, never a signal), and any
+    # nonzero exit carries a sync-failure diagnostic on stderr with no
+    # "panic" text. On Linux fsync/fdatasync on a pipe fails EINVAL, so the
+    # pinned expectation is rc=1 plus a diagnostic.
+    local fdatasync_pipe_err="$TEMP_DIR/dd_fdatasync_pipe.err"
+    "$binary" if=/dev/zero count=1 conv=fdatasync status=none \
+        2>"$fdatasync_pipe_err" | cat >/dev/null
+    local fdatasync_pipe_rc=${PIPESTATUS[0]}
+    local fdatasync_pipe_err_text
+    fdatasync_pipe_err_text=$(cat "$fdatasync_pipe_err")
+    if [[ "$fdatasync_pipe_rc" -eq 1 ]] \
+        && ! grep -qi 'panic' "$fdatasync_pipe_err" \
+        && grep -qi 'sync' "$fdatasync_pipe_err" \
+        && grep -qiE 'fail|invalid' "$fdatasync_pipe_err"; then
+        print_test_result "dd conv=fdatasync on pipe does not panic" "PASS"
+    else
+        print_test_result "dd conv=fdatasync on pipe does not panic" "FAIL" \
+            "rc=$fdatasync_pipe_rc (expected 1, never >=128) stderr='$fdatasync_pipe_err_text'"
+    fi
+
     echo -e "${CYAN}Testing exit codes...${NC}"
 
     # Success exit code


### PR DESCRIPTION
## Summary
GNU parity for the two gaps in #43: `count=`/`skip=`/`seek=`/`iseek=`/`oseek=` now accept the same multiplicative suffix grammar as `bs=` (pure block-count multipliers: `count=1k` = 1024 blocks — GNU-verified byte-for-byte), and `conv=fdatasync` performs a data-only flush before exit (Linux `fdatasync(2)`; full fsync elsewhere and when combined with `conv=fsync`).

The adversarial review then caught that the sync path could SIGABRT: `std.posix.fdatasync` marks EINVAL unreachable, and pipes return EINVAL — so `dd conv=fdatasync | cat` died rc=134 (and `conv=fsync` piped aborted in Debug). The sync path now issues raw syscalls with its own errno switch: fdatasync EINVAL/ENOSYS falls back to full fsync (gnulib behavior), and real failures report GNU-style (`dd: fsync failed for 'standard output': Invalid argument`) with exit 1 — byte-identical to GNU 9.7 on the same commands.

## TDD evidence
- RED (485a3ec): 9 behavioral failures — suffix parsing rejected, fdatasync unrecognized.
- RED (0285899): piped fdatasync dies rc=134 with the panic backtrace at that commit.
- GREEN (4bc1c7c): dd unit tests all pass; `just it-util dd` 38/38; full `zig build test` + `just it` (48 utilities) clean; #44's noerror retry-bound tests unaffected.

## Adversarial review
Approved (round 3, zero findings) — reviewer verified the errno-decoding claim against the installed std source, matched our fallback structure against GNU coreutils' `sync_output`, and live-tested pipes, FIFOs, regular files, and the overflow/edge-suffix matrix. Follow-up candidates recorded (GNU `B`/`kB`/`KiB` suffix family; `0x` zero-multiplier warning; invalid-operand exit code 2 vs GNU's 1 — all pre-existing conventions).

Closes #43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fqscf2s7jmDAEEybsRH6qt

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches post-copy fsync/fdatasync syscalls and exit behavior on failure; scope is limited to dd but piped-output regressions were the main prior failure mode and are now explicitly tested.
> 
> **Overview**
> **dd** gains GNU parity for issue #43: block-count operands **`count=`**, **`skip=`**, **`seek=`**, and **`iseek=`** / **`oseek=`** now parse through the same **`parseByteSize`** suffix grammar as **`bs=`** (e.g. **`count=1k`** = 1024 blocks, not bytes). **`conv=fdatasync`** is recognized and flushed at exit via a new **`runDd_finish_sync`** path (Linux **`fdatasync(2)`** when only fdatasync is set; full **`fsync`** elsewhere, when **`conv=fsync`** is also set, or after EINVAL/ENOSYS fallback).
> 
> The finish sync logic no longer uses std helpers that **panic on EINVAL** when output is a pipe; it issues raw syscalls, maps errno to GNU-style messages (**`fsync failed for 'standard output': Invalid argument`**), and exits **1** instead of **SIGABRT**. Changelog, **`docs/specs/dd-flags.md`**, and **`man/man1/dd.1`** document suffixes and **`fsync`/`fdatasync`**; unit and **`dd_test.sh`** integration tests cover suffix parsing, fdatasync copy, and piped fdatasync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 540a12d33fef823ccdb89e7c3e89456abc5466b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->