### PR TITLE
realpath: require -s '..' prefix to exist as a directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Fixed
+- **realpath `-s` validates the component preceding `..`.**
+  Popping `..` past a missing component now errors `No such
+  file or directory`, and past a file (or symlink to one)
+  errors `Not a directory`, both exit 1, matching GNU. A
+  symlink to a directory is accepted and popped textually;
+  `-m -s` still skips the check entirely (#62).
+
 ## v0.11.0 — 2026-07-02
 
 ### Added

--- a/src/realpath.zig
+++ b/src/realpath.zig
@@ -75,9 +75,69 @@ const RealpathArgs = struct {
     };
 };
 
+/// Join collected path components into an absolute "/c0/c1/..." slice, or "/"
+/// when empty. Caller owns the returned slice.
+fn joinComponentsAbsolute(allocator: Allocator, components: []const []const u8) ![]u8 {
+    if (components.len == 0) {
+        return try allocator.dupe(u8, "/");
+    }
+    // Leading '/' plus one '/' separator and the bytes for each component.
+    var total_len: usize = 0;
+    for (components) |comp| {
+        std.debug.assert(comp.len > 0);
+        total_len += 1 + comp.len;
+    }
+    std.debug.assert(total_len >= components.len);
+
+    const result = try allocator.alloc(u8, total_len);
+    var pos: usize = 0;
+    for (components) |comp| {
+        result[pos] = '/';
+        pos += 1;
+        @memcpy(result[pos .. pos + comp.len], comp);
+        pos += comp.len;
+    }
+    // The build loop writes exactly total_len bytes, so pos lands on total_len.
+    std.debug.assert(pos == total_len);
+    return result;
+}
+
+/// Stat the accumulated prefix that precedes a `..` and confirm it is a
+/// directory (following symlinks, matching GNU realpath -s). Errors with
+/// FileNotFound when the prefix is absent and NotDir when it resolves to a
+/// non-directory. `components` are the path parts collected so far, all
+/// non-empty and never `.`/`..`.
+fn checkDotDotPrefix(
+    allocator: Allocator,
+    io: std.Io,
+    components: []const []const u8,
+) !void {
+    std.debug.assert(components.len > 0);
+    const prefix = try joinComponentsAbsolute(allocator, components);
+    defer allocator.free(prefix);
+    std.debug.assert(prefix.len > 0);
+    const info = try std.Io.Dir.cwd().statFile(io, prefix, .{});
+    if (info.kind != .directory) {
+        return error.NotDir;
+    }
+}
+
+/// Textual logical resolution: clean . and .. purely as text, no filesystem
+/// check. Convenience wrapper used by the pure-algorithm unit tests.
+fn resolveLogical(allocator: Allocator, io: std.Io, path: []const u8) ![]u8 {
+    return resolveLogicalWithMode(allocator, io, path, true);
+}
+
 /// Resolve a path without following symlinks, just cleaning . and .. components.
 /// Makes the path absolute and removes redundant separators and dot components.
-fn resolveLogical(allocator: Allocator, io: std.Io, path: []const u8) ![]u8 {
+/// When `allow_missing` is false (plain -s), each `..` requires the component
+/// it pops to exist and be a directory; -m -s passes true to skip that check.
+fn resolveLogicalWithMode(
+    allocator: Allocator,
+    io: std.Io,
+    path: []const u8,
+    allow_missing: bool,
+) ![]u8 {
     // GNU realpath -s reports "No such file or directory" for an empty operand
     // rather than resolving it to the cwd. Reject it here so an empty
     // --relative-to= base routed through this path errors like GNU.
@@ -114,6 +174,10 @@ fn resolveLogical(allocator: Allocator, io: std.Io, path: []const u8) ![]u8 {
             continue;
         } else if (std.mem.eql(u8, component, "..")) {
             if (components.items.len > 0) {
+                // Under plain -s the popped prefix must exist as a directory.
+                if (!allow_missing) {
+                    try checkDotDotPrefix(allocator, io, components.items);
+                }
                 _ = components.pop();
             }
         } else {
@@ -121,29 +185,8 @@ fn resolveLogical(allocator: Allocator, io: std.Io, path: []const u8) ![]u8 {
         }
     }
 
-    // Build result path
-    if (components.items.len == 0) {
-        return try allocator.dupe(u8, "/");
-    }
-
-    // Calculate total length: leading / + each component + separators
-    var total_len: usize = 0;
-    for (components.items) |comp| {
-        total_len += 1 + comp.len; // '/' + component
-    }
-
-    const result = try allocator.alloc(u8, total_len);
-    var pos: usize = 0;
-    for (components.items) |comp| {
-        result[pos] = '/';
-        pos += 1;
-        @memcpy(result[pos .. pos + comp.len], comp);
-        pos += comp.len;
-    }
-    // The build loop writes exactly total_len bytes, so pos lands on total_len.
-    std.debug.assert(pos == total_len);
-
-    return result;
+    // Build result path from the cleaned components.
+    return try joinComponentsAbsolute(allocator, components.items);
 }
 
 /// Print a "name: message" resolution error with the program prefix. Shared by
@@ -177,7 +220,7 @@ fn processPath_resolveTarget(
     stderr_writer: *std.Io.Writer,
 ) !?[]u8 {
     if (opts.no_symlinks) {
-        return resolveLogical(allocator, io, path) catch |err| {
+        return resolveLogicalWithMode(allocator, io, path, opts.canonicalize_missing) catch |err| {
             if (!opts.quiet) {
                 printResolveError(allocator, stderr_writer, path, err);
             }
@@ -221,7 +264,8 @@ fn processPath_resolveBase(
     stderr_writer: *std.Io.Writer,
 ) !?[]u8 {
     if (opts.no_symlinks) {
-        return resolveLogical(allocator, io, base_dir) catch |err| {
+        const allow_missing = opts.canonicalize_missing;
+        return resolveLogicalWithMode(allocator, io, base_dir, allow_missing) catch |err| {
             if (!opts.quiet) {
                 printResolveError(allocator, stderr_writer, base_dir, err);
             }

--- a/src/realpath.zig
+++ b/src/realpath.zig
@@ -1681,3 +1681,313 @@ test "realpath: -m dotdot past root is clamped" {
     try testing.expectEqual(@as(u8, 0), result);
     try testing.expectEqualStrings(expected, stdout_aw.writer.buffered());
 }
+
+// ============================================================================
+// Issue #62: `-s` must verify the component preceding a `..` exists and is a
+// directory before popping it, instead of popping purely textually. Pinned
+// against GNU coreutils 9.5 on Linux. Under plain `-s`, a missing preceding
+// component -> ENOENT rc=1; a non-directory preceding component (real file or
+// symlink-to-file) -> ENOTDIR rc=1. Under `-m -s`, the check is skipped. The
+// final component of the whole path need not exist under plain `-s`.
+// ============================================================================
+
+// `-s nosuch/../x`: the component before `..` does not exist, so GNU errors
+// "No such file or directory" rc=1 instead of printing <cwd>/x rc=0. This is
+// the primary red for the textual-pop bug.
+test "realpath: -s pop of dotdot past missing component errors ENOENT (issue #62)" {
+    const io = testing.io;
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    var saved_cwd_dir = try std.Io.Dir.cwd().openDir(io, ".", .{});
+    defer {
+        std.process.setCurrentDir(io, saved_cwd_dir) catch {};
+        saved_cwd_dir.close(io);
+    }
+
+    const tmp_abs = try tmp_dir.dir.realPathFileAlloc(io, ".", testing.allocator);
+    defer testing.allocator.free(tmp_abs);
+
+    try std.Io.Threaded.chdir(tmp_abs);
+
+    var stdout_aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer stdout_aw.deinit();
+    var stderr_aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer stderr_aw.deinit();
+
+    const args = [_][]const u8{ "-s", "nosuch/../x" };
+    const result = try runRealpath(
+        testing.allocator,
+        io,
+        &args,
+        &stdout_aw.writer,
+        &stderr_aw.writer,
+    );
+
+    try testing.expectEqual(@as(u8, 1), result);
+    try testing.expectEqual(@as(usize, 0), stdout_aw.writer.buffered().len);
+    try testing.expect(
+        std.mem.find(u8, stderr_aw.writer.buffered(), "No such file or directory") != null,
+    );
+}
+
+// `-s file.txt/../x`: the component before `..` exists but is a regular file,
+// so GNU errors "Not a directory" rc=1 instead of printing <cwd>/x rc=0.
+test "realpath: -s pop of dotdot past non-directory errors ENOTDIR (issue #62)" {
+    const io = testing.io;
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    {
+        const file = try tmp_dir.dir.createFile(io, "file.txt", .{});
+        file.close(io);
+    }
+
+    var saved_cwd_dir = try std.Io.Dir.cwd().openDir(io, ".", .{});
+    defer {
+        std.process.setCurrentDir(io, saved_cwd_dir) catch {};
+        saved_cwd_dir.close(io);
+    }
+
+    const tmp_abs = try tmp_dir.dir.realPathFileAlloc(io, ".", testing.allocator);
+    defer testing.allocator.free(tmp_abs);
+
+    try std.Io.Threaded.chdir(tmp_abs);
+
+    var stdout_aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer stdout_aw.deinit();
+    var stderr_aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer stderr_aw.deinit();
+
+    const args = [_][]const u8{ "-s", "file.txt/../x" };
+    const result = try runRealpath(
+        testing.allocator,
+        io,
+        &args,
+        &stdout_aw.writer,
+        &stderr_aw.writer,
+    );
+
+    try testing.expectEqual(@as(u8, 1), result);
+    try testing.expectEqual(@as(usize, 0), stdout_aw.writer.buffered().len);
+    try testing.expect(
+        std.mem.find(u8, stderr_aw.writer.buffered(), "Not a directory") != null,
+    );
+}
+
+// Absolute path variant: `<tmp>/nosuch/../x` with a missing prefix must fail
+// the same way, proving the check applies to the isAbsolute branch too.
+test "realpath: -s absolute dotdot past missing component errors ENOENT (issue #62)" {
+    const io = testing.io;
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    const tmp_abs = try tmp_dir.dir.realPathFileAlloc(io, ".", testing.allocator);
+    defer testing.allocator.free(tmp_abs);
+
+    const path = try std.fmt.allocPrint(testing.allocator, "{s}/nosuch/../x", .{tmp_abs});
+    defer testing.allocator.free(path);
+
+    var stdout_aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer stdout_aw.deinit();
+    var stderr_aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer stderr_aw.deinit();
+
+    const args = [_][]const u8{ "-s", path };
+    const result = try runRealpath(
+        testing.allocator,
+        io,
+        &args,
+        &stdout_aw.writer,
+        &stderr_aw.writer,
+    );
+
+    try testing.expectEqual(@as(u8, 1), result);
+    try testing.expectEqual(@as(usize, 0), stdout_aw.writer.buffered().len);
+    try testing.expect(
+        std.mem.find(u8, stderr_aw.writer.buffered(), "No such file or directory") != null,
+    );
+}
+
+// `-m -s nosuch/../x`: `-m` (canonicalize_missing) permits missing components,
+// so the per-component check is skipped and the textual result is printed.
+// Guards against a fix that applies the check unconditionally under `-m -s`.
+test "realpath: -m -s pop of dotdot past missing component succeeds (issue #62)" {
+    const io = testing.io;
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    var saved_cwd_dir = try std.Io.Dir.cwd().openDir(io, ".", .{});
+    defer {
+        std.process.setCurrentDir(io, saved_cwd_dir) catch {};
+        saved_cwd_dir.close(io);
+    }
+
+    const tmp_abs = try tmp_dir.dir.realPathFileAlloc(io, ".", testing.allocator);
+    defer testing.allocator.free(tmp_abs);
+
+    try std.Io.Threaded.chdir(tmp_abs);
+
+    const expected = try std.fmt.allocPrint(testing.allocator, "{s}/x\n", .{tmp_abs});
+    defer testing.allocator.free(expected);
+
+    var stdout_aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer stdout_aw.deinit();
+    var stderr_aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer stderr_aw.deinit();
+
+    const args = [_][]const u8{ "-m", "-s", "nosuch/../x" };
+    const result = try runRealpath(
+        testing.allocator,
+        io,
+        &args,
+        &stdout_aw.writer,
+        &stderr_aw.writer,
+    );
+
+    try testing.expectEqual(@as(u8, 0), result);
+    try testing.expectEqualStrings(expected, stdout_aw.writer.buffered());
+}
+
+// `-s sub/../nosuch_final` with `sub` an existing directory: the pop of `..`
+// past `sub` is legal (sub is a directory), and the final component after
+// cleanup need not exist. GNU prints <cwd>/nosuch_final rc=0. Guards against a
+// fix that over-rejects the valid case or that checks the final component.
+test "realpath: -s pop past existing dir with missing final component succeeds (issue #62)" {
+    const io = testing.io;
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    try tmp_dir.dir.createDirPath(io, "sub");
+
+    var saved_cwd_dir = try std.Io.Dir.cwd().openDir(io, ".", .{});
+    defer {
+        std.process.setCurrentDir(io, saved_cwd_dir) catch {};
+        saved_cwd_dir.close(io);
+    }
+
+    const tmp_abs = try tmp_dir.dir.realPathFileAlloc(io, ".", testing.allocator);
+    defer testing.allocator.free(tmp_abs);
+
+    try std.Io.Threaded.chdir(tmp_abs);
+
+    const expected = try std.fmt.allocPrint(testing.allocator, "{s}/nosuch_final\n", .{tmp_abs});
+    defer testing.allocator.free(expected);
+
+    var stdout_aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer stdout_aw.deinit();
+    var stderr_aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer stderr_aw.deinit();
+
+    const args = [_][]const u8{ "-s", "sub/../nosuch_final" };
+    const result = try runRealpath(
+        testing.allocator,
+        io,
+        &args,
+        &stdout_aw.writer,
+        &stderr_aw.writer,
+    );
+
+    try testing.expectEqual(@as(u8, 0), result);
+    try testing.expectEqualStrings(expected, stdout_aw.writer.buffered());
+}
+
+// `-s slink/../file.txt` where `slink` is a symlink to a directory: GNU stat
+// follows the symlink, sees a directory, and pops the `slink` name textually
+// (logical mode never substitutes the target). Result <cwd>/file.txt rc=0.
+test "realpath: -s pop past symlink-to-directory succeeds (issue #62)" {
+    const io = testing.io;
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    try tmp_dir.dir.createDirPath(io, "sub");
+    {
+        const file = try tmp_dir.dir.createFile(io, "file.txt", .{});
+        file.close(io);
+    }
+    tmp_dir.dir.symLink(io, "sub", "slink", .{}) catch |err| {
+        if (err == error.AccessDenied) return;
+        return err;
+    };
+
+    var saved_cwd_dir = try std.Io.Dir.cwd().openDir(io, ".", .{});
+    defer {
+        std.process.setCurrentDir(io, saved_cwd_dir) catch {};
+        saved_cwd_dir.close(io);
+    }
+
+    const tmp_abs = try tmp_dir.dir.realPathFileAlloc(io, ".", testing.allocator);
+    defer testing.allocator.free(tmp_abs);
+
+    try std.Io.Threaded.chdir(tmp_abs);
+
+    const expected = try std.fmt.allocPrint(testing.allocator, "{s}/file.txt\n", .{tmp_abs});
+    defer testing.allocator.free(expected);
+
+    var stdout_aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer stdout_aw.deinit();
+    var stderr_aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer stderr_aw.deinit();
+
+    const args = [_][]const u8{ "-s", "slink/../file.txt" };
+    const result = try runRealpath(
+        testing.allocator,
+        io,
+        &args,
+        &stdout_aw.writer,
+        &stderr_aw.writer,
+    );
+
+    try testing.expectEqual(@as(u8, 0), result);
+    try testing.expectEqualStrings(expected, stdout_aw.writer.buffered());
+}
+
+// `-s flink/../file.txt` where `flink` is a symlink to a regular file: GNU stat
+// follows the symlink, sees a non-directory, and errors "Not a directory" rc=1.
+// The check follows the symlink (statFile, not lstat), so this is a red for the
+// current textual pop. Guards that the fix uses a following stat.
+test "realpath: -s pop past symlink-to-file errors ENOTDIR (issue #62)" {
+    const io = testing.io;
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    {
+        const file = try tmp_dir.dir.createFile(io, "file.txt", .{});
+        file.close(io);
+    }
+    tmp_dir.dir.symLink(io, "file.txt", "flink", .{}) catch |err| {
+        if (err == error.AccessDenied) return;
+        return err;
+    };
+
+    var saved_cwd_dir = try std.Io.Dir.cwd().openDir(io, ".", .{});
+    defer {
+        std.process.setCurrentDir(io, saved_cwd_dir) catch {};
+        saved_cwd_dir.close(io);
+    }
+
+    const tmp_abs = try tmp_dir.dir.realPathFileAlloc(io, ".", testing.allocator);
+    defer testing.allocator.free(tmp_abs);
+
+    try std.Io.Threaded.chdir(tmp_abs);
+
+    var stdout_aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer stdout_aw.deinit();
+    var stderr_aw: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer stderr_aw.deinit();
+
+    const args = [_][]const u8{ "-s", "flink/../file.txt" };
+    const result = try runRealpath(
+        testing.allocator,
+        io,
+        &args,
+        &stdout_aw.writer,
+        &stderr_aw.writer,
+    );
+
+    try testing.expectEqual(@as(u8, 1), result);
+    try testing.expectEqual(@as(usize, 0), stdout_aw.writer.buffered().len);
+    try testing.expect(
+        std.mem.find(u8, stderr_aw.writer.buffered(), "Not a directory") != null,
+    );
+}

--- a/tests/utilities/realpath_test.sh
+++ b/tests/utilities/realpath_test.sh
@@ -93,7 +93,11 @@ test_realpath() {
     # -s should resolve . and .. without following symlinks
     test_command_output "-s resolves .." "/usr/lib" "$binary" -s /usr/bin/../lib
     test_command_output "-s resolves ." "/usr/bin" "$binary" -s /usr/./bin
-    test_command_output "-s resolves complex .." "/a/d" "$binary" -s /a/b/c/../../d
+    # Issue #62: popping '..' requires the preceding component to exist and be a
+    # directory. /a/b/c does not exist on any host, so GNU 9.5 errors ENOENT
+    # rc=1 rather than printing /a/d. (Was previously asserted as "/a/d" rc=0,
+    # which encoded the pre-fix textual-pop bug.)
+    test_command_exit_code "-s errors on complex .. with nonexistent prefix" 1 "$binary" -s /a/b/c/../../d
     test_command_output "-s resolves root .." "/" "$binary" -s /../../..
     test_command_output "-s removes redundant slashes" "/usr/bin/ls" "$binary" -s /usr///bin///ls
 
@@ -395,4 +399,110 @@ test_realpath() {
         print_test_result "empty --relative-to= reports No such file or directory" "FAIL" \
             "Error: $empty_rt_err"
     fi
+
+    # Issue #62: under -s, popping '..' requires the preceding component to
+    # exist and be a directory. Missing -> ENOENT rc=1; a file (or a
+    # symlink-to-file, followed) -> ENOTDIR rc=1. Under -m -s the check is
+    # skipped. The final component after cleanup need not exist under plain -s.
+    echo -e "${CYAN}Testing -s '..' preceding-component check (issue #62)...${NC}"
+
+    local dd_dir="$TEMP_DIR/realpath_dotdot_test"
+    mkdir -p "$dd_dir/sub"
+    echo "test" > "$dd_dir/file.txt"
+    ln -sfn sub "$dd_dir/slink" 2>/dev/null
+    ln -sfn file.txt "$dd_dir/flink" 2>/dev/null
+
+    # Missing preceding component -> ENOENT rc=1 (was <cwd>/x rc=0 pre-fix).
+    local dd_enoent_out dd_enoent_err dd_enoent_rc
+    dd_enoent_out=$(cd "$dd_dir" && "$binary" -s nosuch/../x 2>/dev/null)
+    dd_enoent_err=$(cd "$dd_dir" && "$binary" -s nosuch/../x 2>&1 >/dev/null)
+    (cd "$dd_dir" && "$binary" -s nosuch/../x >/dev/null 2>&1)
+    dd_enoent_rc=$?
+    if [[ "$dd_enoent_rc" -eq 1 && -z "$dd_enoent_out" && \
+          "$dd_enoent_err" == *"No such file or directory"* ]]; then
+        print_test_result "-s '..' past missing component errors ENOENT" "PASS"
+    else
+        print_test_result "-s '..' past missing component errors ENOENT" "FAIL" \
+            "rc=$dd_enoent_rc out='$dd_enoent_out' err='$dd_enoent_err'"
+    fi
+
+    # Preceding component is a regular file -> ENOTDIR rc=1.
+    local dd_enotdir_out dd_enotdir_err dd_enotdir_rc
+    dd_enotdir_out=$(cd "$dd_dir" && "$binary" -s file.txt/../x 2>/dev/null)
+    dd_enotdir_err=$(cd "$dd_dir" && "$binary" -s file.txt/../x 2>&1 >/dev/null)
+    (cd "$dd_dir" && "$binary" -s file.txt/../x >/dev/null 2>&1)
+    dd_enotdir_rc=$?
+    if [[ "$dd_enotdir_rc" -eq 1 && -z "$dd_enotdir_out" && \
+          "$dd_enotdir_err" == *"Not a directory"* ]]; then
+        print_test_result "-s '..' past regular file errors ENOTDIR" "PASS"
+    else
+        print_test_result "-s '..' past regular file errors ENOTDIR" "FAIL" \
+            "rc=$dd_enotdir_rc out='$dd_enotdir_out' err='$dd_enotdir_err'"
+    fi
+
+    # Absolute path with a missing prefix before '..' -> ENOENT rc=1.
+    local dd_abs_rc
+    "$binary" -s "$dd_dir/nosuch/../x" >/dev/null 2>&1
+    dd_abs_rc=$?
+    if [[ "$dd_abs_rc" -eq 1 ]]; then
+        print_test_result "-s absolute '..' past missing prefix errors" "PASS"
+    else
+        print_test_result "-s absolute '..' past missing prefix errors" "FAIL" \
+            "Expected exit 1, got $dd_abs_rc"
+    fi
+
+    # -m -s skips the check: nonexistent components permitted, textual result.
+    local dd_ms_out dd_ms_rc
+    dd_ms_out=$(cd "$dd_dir" && "$binary" -m -s nosuch/../x 2>/dev/null)
+    dd_ms_rc=$?
+    if [[ "$dd_ms_rc" -eq 0 && "$dd_ms_out" == "$dd_dir/x" ]]; then
+        print_test_result "-m -s '..' past missing component succeeds" "PASS"
+    else
+        print_test_result "-m -s '..' past missing component succeeds" "FAIL" \
+            "Expected exit 0 and '$dd_dir/x', got rc=$dd_ms_rc out='$dd_ms_out'"
+    fi
+
+    # Preceding component is a real directory; final component may be missing.
+    local dd_ok_out dd_ok_rc
+    dd_ok_out=$(cd "$dd_dir" && "$binary" -s sub/../nosuch_final 2>/dev/null)
+    dd_ok_rc=$?
+    if [[ "$dd_ok_rc" -eq 0 && "$dd_ok_out" == "$dd_dir/nosuch_final" ]]; then
+        print_test_result "-s '..' past existing dir, missing final, succeeds" "PASS"
+    else
+        print_test_result "-s '..' past existing dir, missing final, succeeds" "FAIL" \
+            "Expected exit 0 and '$dd_dir/nosuch_final', got rc=$dd_ok_rc out='$dd_ok_out'"
+    fi
+
+    # symlink-to-directory before '..': stat follows, sees a dir, pops textually.
+    if [[ -L "$dd_dir/slink" ]]; then
+        local dd_slink_out dd_slink_rc
+        dd_slink_out=$(cd "$dd_dir" && "$binary" -s slink/../file.txt 2>/dev/null)
+        dd_slink_rc=$?
+        if [[ "$dd_slink_rc" -eq 0 && "$dd_slink_out" == "$dd_dir/file.txt" ]]; then
+            print_test_result "-s '..' past symlink-to-dir succeeds" "PASS"
+        else
+            print_test_result "-s '..' past symlink-to-dir succeeds" "FAIL" \
+                "Expected exit 0 and '$dd_dir/file.txt', got rc=$dd_slink_rc out='$dd_slink_out'"
+        fi
+    else
+        print_test_result "-s '..' past symlink-to-dir succeeds" "SKIP" "Cannot create symlinks"
+    fi
+
+    # symlink-to-file before '..': stat follows, sees a non-dir -> ENOTDIR rc=1.
+    if [[ -L "$dd_dir/flink" ]]; then
+        local dd_flink_err dd_flink_rc
+        dd_flink_err=$(cd "$dd_dir" && "$binary" -s flink/../file.txt 2>&1 >/dev/null)
+        (cd "$dd_dir" && "$binary" -s flink/../file.txt >/dev/null 2>&1)
+        dd_flink_rc=$?
+        if [[ "$dd_flink_rc" -eq 1 && "$dd_flink_err" == *"Not a directory"* ]]; then
+            print_test_result "-s '..' past symlink-to-file errors ENOTDIR" "PASS"
+        else
+            print_test_result "-s '..' past symlink-to-file errors ENOTDIR" "FAIL" \
+                "rc=$dd_flink_rc err='$dd_flink_err'"
+        fi
+    else
+        print_test_result "-s '..' past symlink-to-file errors ENOTDIR" "SKIP" "Cannot create symlinks"
+    fi
+
+    rm -rf "$dd_dir"
 }


### PR DESCRIPTION
Fixes #62.

`realpath -s` popped `..` purely textually: `realpath -s nosuch/../x` printed `<cwd>/x` rc=0 where GNU 9.5 errors `No such file or directory` rc=1, and `realpath -s file/../x` succeeded where GNU errors `Not a directory`. Thirteen GNU behaviors pinned verbatim on ubuntu via OrbStack, including the edge cases: symlink-to-dir before `..` is accepted (popped textually, target never substituted), symlink-to-file errors ENOTDIR, `-m -s` skips the check entirely (even `file/../x`), the final component may be missing, and root `..` stays a no-op.

## Changes
- `resolveLogicalWithMode` replaces `resolveLogical` with an `allow_missing` mode: plain `-s` stats the accumulated prefix (following symlinks) before each `..` pop via a new `checkDotDotPrefix` helper; `-m -s` passes `allow_missing=true` and keeps the pure textual pop. Both call sites (`processPath_resolveTarget`, `processPath_resolveBase`) thread `opts.canonicalize_missing`.
- The result builder was extracted into `joinComponentsAbsolute` and reused by the prefix check.
- One legacy integration case (`-s /a/b/c/../../d` → `/a/d`) encoded the buggy textual-pop behavior and now expects GNU's rc=1 (`/a` doesn't exist).

## Tests
- 7 unit tests + 6 integration cases (4 RED before the fix, 3 guards green throughout), all pinned to GNU 9.5 output.
- RED verified for the right reason on macOS and Linux before the fix.

## Verification
- Full unit, privileged, and integration suites green on macOS; full unit + realpath integration green on Linux (orb ubuntu).
- Tiger check: clean (2 usize candidates triaged as std-API-required). Code review: APPROVED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LVBjGz3hMGA62gKRZNbidE

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped correctness fix in `realpath` logical resolution with GNU-aligned tests; extra `stat` calls on `..` under `-s` only, no auth or shared infrastructure changes.
> 
> **Overview**
> Fixes **#62** by changing how **`realpath -s`** handles **`..`**: instead of always popping parent segments textually, plain **`-s`** now **stats the accumulated prefix** (following symlinks) and requires it to be a **directory** before the pop. Missing prefixes yield **ENOENT** (exit 1); files or symlink-to-file yield **ENOTDIR**. **`-m -s`** passes **`allow_missing`** so the old textual behavior remains.
> 
> Implementation adds **`resolveLogicalWithMode`**, **`checkDotDotPrefix`**, and shared **`joinComponentsAbsolute`**, wired from **`processPath_resolveTarget`** and **`processPath_resolveBase`** via **`opts.canonicalize_missing`**. A legacy integration expectation (`-s /a/b/c/../../d` → `/a/d`) is corrected to expect **exit 1**. **Seven unit tests** and an expanded **`realpath_test.sh`** section pin GNU 9.5 behavior (symlink-to-dir OK, symlink-to-file fails, final component may still be missing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f821302230a239f6a1d1abfb06bef3cdb811490. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->