### PR TITLE
mv/chmod: render errno strings, drop redundant chmod error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+### Added
+- **dd accepts the full GNU size-suffix family with byte
+  semantics.** `bs=`/`ibs=`/`obs=` and the count-like operands
+  now take `B`, decimal `kB`/`MB`/`GB`/`TB`/`PB`/`EB`, and
+  binary `K`/`KiB` through `E`/`EiB` suffixes. On
+  `count=`/`skip=`/`seek=`, a suffix ending in `B` counts
+  exact BYTES rather than blocks (`bs=512 count=1kB` copies
+  exactly 1000 bytes; byte-precise skip/seek offsets), matching
+  GNU. A zero multiplier such as `count=0x10` now emits GNU's
+  `'0x' is a zero multiplier` warning (#65).
+
 ### Changed
 - **Error messages quote operands exactly as GNU does.** Every
   diagnostic that names a user operand was audited against GNU
@@ -16,34 +27,16 @@
   verbatim (#63).
 
 ### Fixed
-- **cat reports `Is a directory` for directory operands.**
-  Reading a directory leaked Zig's raw `ReadFailed` error name
-  (`cat: somedir: ReadFailed`); cat now stats the operand and
-  reports `cat: somedir: Is a directory` with exit 1, matching
-  GNU. Found by the new quoting-parity tests.
-- **grep -r names the exact unreadable directory.** The walker
-  now records the path of a directory it fails to open, and
-  grep reports that path directly. The previous rescan
-  heuristic could name a readable sibling depending on readdir
-  order.
-
-### Added
-- **dd accepts the full GNU size-suffix family with byte
-  semantics.** `bs=`/`ibs=`/`obs=` and the count-like operands
-  now take `B`, decimal `kB`/`MB`/`GB`/`TB`/`PB`/`EB`, and
-  binary `K`/`KiB` through `E`/`EiB` suffixes. On
-  `count=`/`skip=`/`seek=`, a suffix ending in `B` counts
-  exact BYTES rather than blocks (`bs=512 count=1kB` copies
-  exactly 1000 bytes; byte-precise skip/seek offsets), matching
-  GNU. A zero multiplier such as `count=0x10` now emits GNU's
-  `'0x' is a zero multiplier` warning (#65).
-
-### Fixed
-- **dd names the offending value in operand errors.**
-  `dd count=1m` now reports `invalid number: '1m'` in GNU's
-  message shape instead of a generic `invalid operand value`;
-  the exit code stays 2 per the project-wide misuse convention
-  (#64).
+- **mv renders the errno string instead of a raw Zig error name.**
+  A failed move (missing source, unremovable source, backup
+  failure, and others) printed `error.FileNotFound` and similar
+  internal names; every mv diagnostic now maps the error to its
+  GNU strerror text (`No such file or directory`).
+- **chmod no longer appends a redundant error line for an invalid
+  mode.** An invalid numeric mode such as `999` reported `invalid
+  mode: '999'` and then a spurious `operation failed:
+  InvalidOctalMode` leaking the raw error variant; the redundant
+  second line is gone, matching GNU's single diagnostic.
 - **chown/chmod `-RL` reach directories aliased by sibling
   symlinks.** The walker's global visited set skipped whichever
   of a directory and a symlink to it was seen second, so the
@@ -69,11 +62,25 @@
   0/1 as if the truncated results were complete. Matching GNU,
   errors dominate a found match unless `-q` is given; under
   `-q` with no match, an error still exits 2 (#58).
+- **grep `-r` names the exact unreadable directory.** The walker
+  now records the path of a directory it fails to open, and grep
+  reports that path directly. The previous rescan heuristic could
+  name a readable sibling depending on readdir order.
+- **dd names the offending value in operand errors.**
+  `dd count=1m` now reports `invalid number: '1m'` in GNU's
+  message shape instead of a generic `invalid operand value`;
+  the exit code stays 2 per the project-wide misuse convention
+  (#64).
 - **dd `conv=noerror,sync` counts error-synthesized blocks as
   partial records in.** Blocks NUL-padded after a read error
   (zero bytes actually read) now report as `0+N records in`,
   matching GNU; they were previously counted as full. The
   padded writes still count as full records out (#59).
+- **cat reports `Is a directory` for directory operands.**
+  Reading a directory leaked Zig's raw `ReadFailed` error name
+  (`cat: somedir: ReadFailed`); cat now stats the operand and
+  reports `cat: somedir: Is a directory` with exit 1, matching
+  GNU. Found by the new quoting-parity tests.
 
 ### Infrastructure
 - **Walker cycle detection split into modes.** The single

--- a/src/chmod.zig
+++ b/src/chmod.zig
@@ -139,20 +139,32 @@ pub fn runChmod(
     return @intFromEnum(common.ExitCode.success);
 }
 
-/// Report a top-level chmodFiles failure. FileOperationFailed means individual
-/// entries already printed their own diagnostics, so we stay silent; any other
-/// error is an unexpected operation failure worth surfacing once.
+/// Report a top-level chmodFiles failure. FileOperationFailed, InvalidMode, and
+/// InvalidOctalMode all mean a diagnostic was already printed upstream (either
+/// the per-file failure, or resolveModeSpec's "invalid mode" message), so we
+/// stay silent for those; any other error is an unexpected operation failure
+/// worth surfacing once.
 fn reportChmodFilesError(
     allocator: std.mem.Allocator,
     stderr_writer: anytype,
     err: anyerror,
     options: ChmodOptions,
 ) void {
+    // Precompute membership so each branch below asserts a single condition
+    // rather than a compound boolean (Tiger Style splits compound asserts).
+    const already_reported = err == ChmodError.FileOperationFailed or
+        err == ChmodError.InvalidMode or
+        err == ChmodError.InvalidOctalMode;
     switch (err) {
-        ChmodError.FileOperationFailed => {
-            // Specific file errors already reported, just return failure code.
+        ChmodError.FileOperationFailed, ChmodError.InvalidMode, ChmodError.InvalidOctalMode => {
+            // Positive space: this branch is only reached for the three
+            // variants already reported upstream.
+            assert(already_reported);
         },
         else => {
+            // Negative space: this branch never fires for the three variants
+            // already reported upstream.
+            assert(!already_reported);
             if (!options.quiet) {
                 common.printErrorWithProgram(
                     allocator,

--- a/src/mv.zig
+++ b/src/mv.zig
@@ -560,8 +560,8 @@ fn crossFilesystemMove(
             allocator,
             stderr_writer,
             "mv",
-            "cannot stat '{s}': {}",
-            .{ source, err },
+            "cannot stat '{s}': {s}",
+            .{ source, common.posixErrorString(err) },
         );
         return err;
     };
@@ -626,8 +626,8 @@ fn removeSourceAfterCopy(
                 allocator,
                 stderr_writer,
                 "mv",
-                "failed to remove source directory '{s}': {}",
-                .{ source, del_err },
+                "failed to remove source directory '{s}': {s}",
+                .{ source, common.posixErrorString(del_err) },
             );
             common.printErrorWithProgram(
                 allocator,
@@ -644,8 +644,8 @@ fn removeSourceAfterCopy(
                 allocator,
                 stderr_writer,
                 "mv",
-                "failed to remove source file '{s}': {}",
-                .{ source, del_err },
+                "failed to remove source file '{s}': {s}",
+                .{ source, common.posixErrorString(del_err) },
             );
             common.printErrorWithProgram(
                 allocator,
@@ -806,8 +806,8 @@ fn materializeDestDir(
                 allocator,
                 stderr_writer,
                 "mv",
-                "cannot create directory '{s}': {}",
-                .{ dest_path, err },
+                "cannot create directory '{s}': {s}",
+                .{ dest_path, common.posixErrorString(err) },
             );
             return err;
         },
@@ -833,8 +833,8 @@ fn preserveCopiedDir(
             allocator,
             stderr_writer,
             "mv",
-            "cannot stat directory '{s}': {}",
-            .{ source_path, err },
+            "cannot stat directory '{s}': {s}",
+            .{ source_path, common.posixErrorString(err) },
         );
         return err;
     };
@@ -873,8 +873,8 @@ fn copyTreeFile(
             allocator,
             stderr_writer,
             "mv",
-            "cannot stat file '{s}': {}",
-            .{ source_path, err },
+            "cannot stat file '{s}': {s}",
+            .{ source_path, common.posixErrorString(err) },
         );
         return err;
     };
@@ -911,8 +911,8 @@ fn recreateSymlink(
             allocator,
             stderr_writer,
             "mv",
-            "cannot read symlink '{s}': {}",
-            .{ source_path, err },
+            "cannot read symlink '{s}': {s}",
+            .{ source_path, common.posixErrorString(err) },
         );
         return err;
     };
@@ -922,8 +922,8 @@ fn recreateSymlink(
             allocator,
             stderr_writer,
             "mv",
-            "cannot create symlink '{s}': {}",
-            .{ dest_path, err },
+            "cannot create symlink '{s}': {s}",
+            .{ dest_path, common.posixErrorString(err) },
         );
         return err;
     };
@@ -953,8 +953,8 @@ fn recoverDescendError(
             allocator,
             stderr_writer,
             "mv",
-            "cannot access '{s}': {}",
-            .{ source, walk_err },
+            "cannot access '{s}': {s}",
+            .{ source, common.posixErrorString(walk_err) },
         );
         return;
     }
@@ -963,8 +963,8 @@ fn recoverDescendError(
             allocator,
             stderr_writer,
             "mv",
-            "cannot access '{s}': {}",
-            .{ parent_path, walk_err },
+            "cannot access '{s}': {s}",
+            .{ parent_path, common.posixErrorString(walk_err) },
         );
         return;
     };
@@ -1017,8 +1017,8 @@ fn recoverChild(
         allocator,
         stderr_writer,
         "mv",
-        "cannot access '{s}': {}",
-        .{ child_source, walk_err },
+        "cannot access '{s}': {s}",
+        .{ child_source, common.posixErrorString(walk_err) },
     );
 }
 
@@ -1226,8 +1226,8 @@ fn moveFile_handleSameFile(
             allocator,
             stderr_writer,
             "mv",
-            "cannot remove '{s}': {}",
-            .{ source, err },
+            "cannot remove '{s}': {s}",
+            .{ source, common.posixErrorString(err) },
         );
         return error.SameFile;
     };
@@ -1262,8 +1262,8 @@ fn moveFile_checkNoClobber(
                 allocator,
                 stderr_writer,
                 "mv",
-                "error checking destination '{s}': {}",
-                .{ dest, err },
+                "error checking destination '{s}': {s}",
+                .{ dest, common.posixErrorString(err) },
             );
             return err;
         },
@@ -1288,8 +1288,8 @@ fn moveFile_createBackup(
             allocator,
             stderr_writer,
             "mv",
-            "cannot create backup '{s}': {}",
-            .{ backup_name, backup_err },
+            "cannot create backup '{s}': {s}",
+            .{ backup_name, common.posixErrorString(backup_err) },
         );
         return backup_err;
     };
@@ -1340,8 +1340,8 @@ fn moveFile_handlePathExists(
             allocator,
             stderr_writer,
             "mv",
-            "cannot rename '{s}' to '{s}': {}",
-            .{ source, dest, retry_err },
+            "cannot rename '{s}' to '{s}': {s}",
+            .{ source, dest, common.posixErrorString(retry_err) },
         );
         return retry_err;
     };
@@ -1399,8 +1399,8 @@ fn moveFile_renameOrFallback(
                 allocator,
                 stderr_writer,
                 "mv",
-                "cannot rename '{s}' to '{s}': {}",
-                .{ source, dest, err },
+                "cannot rename '{s}' to '{s}': {s}",
+                .{ source, dest, common.posixErrorString(err) },
             );
             return err;
         },

--- a/tests/utilities/chmod_test.sh
+++ b/tests/utilities/chmod_test.sh
@@ -253,6 +253,20 @@ test_chmod() {
     test_command_fails "chmod invalid octal 999" "$binary" 999 "$test_file1"
     test_command_fails "chmod invalid octal 888" "$binary" 888 "$test_file1"
 
+    # Regression: an invalid numeric mode reports "invalid mode: '999'" once.
+    # It must NOT append a second "operation failed: InvalidOctalMode" line
+    # leaking the raw Zig error variant. GNU prints only "invalid mode".
+    local chmod_badmode_stderr
+    chmod_badmode_stderr=$("$binary" 999 "$test_file1" 2>&1 >/dev/null)
+    if [[ "$chmod_badmode_stderr" == *"invalid mode: '999'"* && \
+          "$chmod_badmode_stderr" != *"operation failed"* && \
+          "$chmod_badmode_stderr" != *"InvalidOctalMode"* ]]; then
+        print_test_result "chmod invalid numeric mode has no redundant error line" "PASS"
+    else
+        print_test_result "chmod invalid numeric mode has no redundant error line" "FAIL" \
+            "Expected single \"invalid mode: '999'\" line without raw variant, got: '$chmod_badmode_stderr'"
+    fi
+
     # Test invalid symbolic modes
     test_command_fails "chmod invalid symbolic xyz" "$binary" xyz "$test_file1"
     test_command_fails "chmod invalid operator u%r" "$binary" "u%r" "$test_file1"

--- a/tests/utilities/mv_test.sh
+++ b/tests/utilities/mv_test.sh
@@ -334,6 +334,19 @@ test_mv() {
     # Non-existent source
     test_command_fails "mv non-existent source" "$binary" "/nonexistent/source.txt" "$TEMP_DIR/dest.txt"
 
+    # Regression: a missing source must render the errno string, never leak
+    # Zig's raw error name. GNU: "mv: cannot stat 'src': No such file or
+    # directory". We at minimum must not print "error.FileNotFound".
+    local mv_nonexist_stderr
+    mv_nonexist_stderr=$("$binary" "/nonexistent/mv_src.txt" "$TEMP_DIR/mv_dst.txt" 2>&1 >/dev/null)
+    if [[ "$mv_nonexist_stderr" != *"error."* && \
+          "$mv_nonexist_stderr" == *"No such file or directory"* ]]; then
+        print_test_result "mv missing source renders errno, not raw error name" "PASS"
+    else
+        print_test_result "mv missing source renders errno, not raw error name" "FAIL" \
+            "Expected 'No such file or directory' and no 'error.' leak, got: '$mv_nonexist_stderr'"
+    fi
+
     # Move to non-existent directory
     local exist_src=$(create_temp_file "Existing file")
     test_command_fails "mv to non-existent directory" "$binary" "$exist_src" "/nonexistent/dir/file.txt"


### PR DESCRIPTION
Two raw Zig error-variant names leaking to stderr, surfaced by smoke-testing every built utility before the v0.12.0 release. Same class as the recent GNU-message sweep (#63).

## mv
Every mv diagnostic formatted the caught error with `{}`, printing internal names like `error.FileNotFound`:
```
mv: cannot rename 'x' to 'y': error.FileNotFound
```
All 16 sites now route the error through `common.posixErrorString`, so users see `No such file or directory` (GNU strerror text). Message wording and operand quoting are unchanged.

## chmod
An invalid numeric mode printed the correct diagnostic and then a spurious second line leaking the raw variant:
```
chmod: invalid mode: '999'
chmod: operation failed: InvalidOctalMode   ← removed
```
`reportChmodFilesError` now stays silent for `InvalidMode`/`InvalidOctalMode` (already reported upstream by `resolveModeSpec`), matching GNU's single diagnostic.

## Testing
Tests written first (separate from the fix), verified RED on macOS and Linux for the right reason, then GREEN on both. Full mv (110) and chmod (111) integration suites pass with Failed: 0; full unit suite green on macOS and Linux.

Also folds the release changelog into a single Added/Changed/Fixed/Infrastructure ordering under `## Unreleased`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-visible stderr wording only; no changes to move, chmod, or permission logic beyond suppressing duplicate chmod diagnostics.
> 
> **Overview**
> **mv** error paths no longer print Zig internal names like `error.FileNotFound` in stderr. Every affected diagnostic now formats the caught error with `common.posixErrorString` (GNU-style text such as `No such file or directory`); message templates and operand quoting are unchanged.
> 
> **chmod** stops emitting a second line after an invalid numeric mode. When `resolveModeSpec` already printed `invalid mode: '999'`, `reportChmodFilesError` now treats `InvalidMode` and `InvalidOctalMode` like other upstream-reported failures and stays silent instead of adding `operation failed: InvalidOctalMode`.
> 
> The unreleased **CHANGELOG** is reordered into Added / Changed / Fixed / Infrastructure. **Integration tests** in `chmod_test.sh` and `mv_test.sh` lock in the single-line chmod behavior and errno-style mv output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44d6f1650d979aba62dc0214fd25374bf0560cfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->