### PR TITLE
chore: refresh actionlint lock + reopen Unreleased changelog section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## Unreleased
+
 ## v0.12.0 — 2026-07-03
 
 ### Added

--- a/gale.lock
+++ b/gale.lock
@@ -1,8 +1,8 @@
 [packages]
   [packages.actionlint]
     version = "1.7.12-2"
-    sha256 = "184a926cdc026be006ea1c55ab1c6ca6c4bc315e0e1fa8802e9b939a270b1d1e"
-    manifest_digest = "sha256:3da15c339f2170fcfc91385d1ddc1963f2d34072cedcdfe9c3a8a6e633539758"
+    sha256 = "d8abea7150172c3a8356f07f6ebbf711d40793e92a092ad15024bb5724d8634b"
+    manifest_digest = "sha256:aafc263432f0c4a6f104f4f1baab59795c1b3944088e5737d688c921a183d976"
   [packages.zig]
     version = "0.16.0-1"
     sha256 = "e6407395e6765d81612de3314ebccf1d8d1e75e8bab34eae6ee0bc571c294a26"


### PR DESCRIPTION
Two post-release chores:

**1. gale.lock — actionlint 1.7.12 → 1.7.12-2.** `gale update` resolved the newer build; refreshes the recorded `sha256`/`manifest_digest`. `gale.toml` keeps the loose pin; zig stays pinned. Dev/CI lint tooling only (used by `just lint-actions`), no effect on built utilities.

**2. CHANGELOG.md — reopen `## Unreleased`.** `just release` promotes `## Unreleased` to the version heading but does not re-add an empty Unreleased for the next cycle. Once the `v0.12.0` tag exists, `lint-changelog` requires the first heading to be `## Unreleased` again (the release-window exemption no longer applies), so main was left in a lint-failing state. This restores the heading.

Both verified locally: `just lint-actions` and `just lint-changelog` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev dependency lock refresh and changelog scaffolding only; no product code or CI workflow logic changes.
> 
> **Overview**
> Updates **`gale.lock`** after `gale update` for the **actionlint `1.7.12-2`** build: new **`sha256`** and **`manifest_digest`** while the loose **`1.7.12`** pin in `gale.toml` is unchanged.
> 
> Adds an empty **`## Unreleased`** heading at the top of **`CHANGELOG.md`** so the changelog structure gate stays satisfied.
> 
> No shipped utility or runtime behavior changes—only the actionlint binary used by **`just lint-actions`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 829a95242d2a756bedc44274ab3202f4373217d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->