### PR TITLE
release: reopen Unreleased after promotion; ignore gale.toml.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ local_*
 # Gale local state (gale.lock is tracked, .gale/ store is not)
 .gale/
 gale.lock.lock
+gale.toml.lock
 
 # Project-local AI tool state
 .pi/

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -140,9 +140,22 @@ echo "Updated build.zig.zon"
 sed -i.bak "s/version = \"${CURRENT}\"/version = \"${VERSION}\"/" flake.nix && rm -f flake.nix.bak
 echo "Updated flake.nix"
 
-# Promote "## Unreleased" to "## v${VERSION} — <date>" in CHANGELOG.md
+# Promote "## Unreleased" to "## v${VERSION} — <date>" in CHANGELOG.md and
+# reopen a fresh empty "## Unreleased" above it for the next cycle. Without
+# the reopen, lint-changelog fails once the tag exists (the release-window
+# exemption that lets a version heading sit first expires at tag creation).
+# awk (not sed) so the newline insertion is portable across BSD and GNU.
 TODAY=$(date +%Y-%m-%d)
-sed -i.bak "s/^## Unreleased$/## v${VERSION} — ${TODAY}/" "$NOTES_FILE" && rm -f "$NOTES_FILE.bak"
+awk -v ver="$VERSION" -v today="$TODAY" '
+    !done && $0 == "## Unreleased" {
+        print "## Unreleased"
+        print ""
+        print "## v" ver " — " today
+        done = 1
+        next
+    }
+    { print }
+' "$NOTES_FILE" > "$NOTES_FILE.tmp" && mv "$NOTES_FILE.tmp" "$NOTES_FILE"
 echo "Updated $NOTES_FILE"
 
 # Verify the updates took effect


### PR DESCRIPTION
Two follow-ups from the v0.12.0 release.

**1. `scripts/release.sh` — auto-reopen `## Unreleased`.** The promotion step renamed `## Unreleased` to the version heading but left nothing in its place. Once the tag exists, `lint-changelog` requires the first heading to be `## Unreleased` again (the release-window exemption that permits a version heading on top expires at tag creation), so `main` landed in a lint-failing state after v0.12.0 (fixed manually in #74). Promotion now reinserts a fresh empty `## Unreleased` above the version heading, so the next release cycle starts clean and CI stays green post-tag.

Uses `awk` rather than `sed` for the insertion — portable newline handling across macOS (BSD) and Linux (GNU). Verified the output is byte-identical to the existing format, em-dash included (U+2014), and the script's own post-promotion `grep` validation still matches.

**2. `.gitignore` — ignore `gale.toml.lock`.** The transient lock `gale update` writes while mutating `gale.toml`, alongside the already-ignored `gale.lock.lock`.

Verified locally: `bash -n scripts/release.sh` clean, awk promotion tested against a sample changelog, `git check-ignore gale.toml.lock` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release automation and ignore-list only; no runtime or security-sensitive code paths.
> 
> **Overview**
> **Release script** now leaves a fresh empty **`## Unreleased`** at the top of `CHANGELOG.md` when it promotes the old section to a versioned heading, instead of only renaming that line. That keeps **`lint-changelog`** passing after the tag exists (the brief exemption for a version heading first ends at tag creation). Promotion uses **awk** instead of **sed** so the extra blank line and heading insert the same on BSD and GNU.
> 
> **`.gitignore`** adds **`gale.toml.lock`**, the transient lock from **`gale update`** on `gale.toml`, next to the existing **`gale.lock.lock`** entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15d009e8c3af7e884ec2b9c78b5c1174d62542ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->