### PR TITLE
gale: bump actionlint recipe to 1.7.12-2

### DIFF
--- a/gale.toml
+++ b/gale.toml
@@ -1,6 +1,6 @@
 [packages]
 zig = "0.16.0-1"
-  actionlint = "1.7.12"
+  actionlint = "1.7.12-2"
 
 [pinned]
 zig = true


### PR DESCRIPTION
`gale.toml` still declared the loose `actionlint = "1.7.12"` while the lock and the installed build had moved to `1.7.12-2` (#74), so `gale outdated` kept flagging the gap. This bumps the declared recipe version to match, consistent with zig's build-suffixed `0.16.0-1` pin.

After the bump `gale outdated` reports "Everything is up to date"; the lock is unchanged (already `1.7.12-2`) and `just lint-actions` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single dependency version string change in gale.toml with no code or lockfile updates; tooling alignment only.
> 
> **Overview**
> Updates the **gale** package declaration for `actionlint` from `1.7.12` to **`1.7.12-2`** so it matches the build-suffixed recipe already recorded in **`gale.lock`** and installed locally.
> 
> This is a **version string alignment only** (same pattern as `zig = "0.16.0-1"`); it stops **`gale outdated`** from reporting a mismatch when the lock was already on `1.7.12-2`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f84f659d7a2de124df21d57d9d5293c8ca515a98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->